### PR TITLE
Sdk 142 - Dns client

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -105,6 +105,9 @@ scorex {
     # List of IP addresses of well known nodes.
     knownPeers = []
 
+    # List of known DNS seeder.
+    knownSeeders = []
+
     # Interval between GetPeers messages to be send by our node to a random one
     getPeersInterval = 2m
 

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -1,7 +1,5 @@
 package scorex.core.network
 
-import java.net._
-
 import akka.actor._
 import akka.io.Tcp._
 import akka.io.{IO, Tcp}
@@ -9,15 +7,17 @@ import akka.pattern.ask
 import akka.util.Timeout
 import scorex.core.app.{ScorexContext, Version}
 import scorex.core.network.NodeViewSynchronizer.ReceivableMessages.{DisconnectedPeer, HandshakedPeer}
+import scorex.core.network.PeerSynchronizer.ReceivableMessages.GetNewPeers
 import scorex.core.network.message.Message.MessageCode
 import scorex.core.network.message.{Message, MessageSpec}
 import scorex.core.network.peer.PeerManager.ReceivableMessages._
-import scorex.core.network.peer.{LocalAddressPeerFeature, PeerInfo, PeerManager, PeersStatus, PenaltyType, SessionIdPeerFeature}
+import scorex.core.network.peer._
 import scorex.core.settings.NetworkSettings
 import scorex.core.utils.TimeProvider.Time
 import scorex.core.utils.{NetworkUtils, TimeProvider}
 import scorex.util.ScorexLogging
 
+import java.net._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.{existentials, postfixOps}
@@ -139,6 +139,9 @@ class NetworkController(settings: NetworkSettings,
 
     case Blacklisted(peerAddress) =>
       closeConnection(peerAddress)
+
+    case EmptyPeerDatabase() =>
+      context.system.eventStream.publish(GetNewPeers())
   }
 
   private def connectionEvents: Receive = {

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -504,6 +504,8 @@ object NetworkController {
 
     case object GetConnectedPeers
 
+    case class EmptyPeerDatabase()
+
     /**
       * Get p2p network status
       */

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -4,13 +4,18 @@ import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, RegisterMessageSpecs, SendToNetwork}
+import scorex.core.network.PeerSynchronizer.ReceivableMessages.GetNewPeers
+import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
+import scorex.core.network.dns.strategy.Response.LookupResponse
+import scorex.core.network.dns.strategy.Strategy.LeastNodeQuantity
 import scorex.core.network.message.{GetPeersSpec, Message, MessageSpec, PeersSpec}
+import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddOrUpdatePeer, AddPeerIfEmpty, SeenPeers}
 import scorex.core.network.peer.{PeerInfo, PenaltyType}
-import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddPeerIfEmpty, SeenPeers}
 import scorex.core.settings.NetworkSettings
 import scorex.util.ScorexLogging
 import shapeless.syntax.typeable._
 
+import java.net.InetSocketAddress
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -19,6 +24,7 @@ import scala.concurrent.duration._
   */
 class PeerSynchronizer(val networkControllerRef: ActorRef,
                        peerManager: ActorRef,
+                       dnsClientRef: ActorRef,
                        settings: NetworkSettings,
                        featureSerializers: PeerFeature.Serializers)
                       (implicit ec: ExecutionContext) extends Actor with Synchronizer with ScorexLogging {
@@ -38,6 +44,8 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 
     networkControllerRef ! RegisterMessageSpecs(Seq(GetPeersSpec, peersSpec), self)
 
+    context.system.eventStream.subscribe(self, classOf[GetNewPeers])
+
     val msg = Message[Unit](GetPeersSpec, Right(Unit), None)
     val stn = SendToNetwork(msg, SendToRandom)
     context.system.scheduler.scheduleWithFixedDelay(2.seconds, settings.getPeersInterval, networkControllerRef, stn)
@@ -47,6 +55,17 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 
     // data received from a remote peer
     case Message(spec, Left(msgBytes), Some(source)) => parseAndHandle(spec, msgBytes, source)
+
+    // TODO: it could be a good idea to pass the peers left in the db or some other criteria
+    // TODO: to decide the lookup strategy
+    case GetNewPeers() =>
+      dnsClientRef ! LookupRequest(LeastNodeQuantity())
+
+    case LookupResponse(ipv4Addresses, _) =>
+      val defaultPort = settings.bindAddress.getPort
+      ipv4Addresses.foreach(
+        address => peerManager ! AddOrUpdatePeer(PeerInfo.fromAddress(new InetSocketAddress(address, defaultPort)))
+      )
 
     // fall-through method for reporting unhandled messages
     case nonsense: Any => log.warn(s"PeerSynchronizer: got unexpected input $nonsense from ${sender()}")
@@ -82,16 +101,22 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
   }
 }
 
+object PeerSynchronizer {
+  object ReceivableMessages {
+    case class GetNewPeers()
+  }
+}
+
 object PeerSynchronizerRef {
-  def props(networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings,
+  def props(networkControllerRef: ActorRef, peerManager: ActorRef, dnsClientRef: ActorRef, settings: NetworkSettings,
             featureSerializers: PeerFeature.Serializers)(implicit ec: ExecutionContext): Props =
-    Props(new PeerSynchronizer(networkControllerRef, peerManager, settings, featureSerializers))
+    Props(new PeerSynchronizer(networkControllerRef, peerManager, dnsClientRef, settings, featureSerializers))
 
-  def apply(networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings,
+  def apply(networkControllerRef: ActorRef, peerManager: ActorRef, dnsClientRef: ActorRef, settings: NetworkSettings,
             featureSerializers: PeerFeature.Serializers)(implicit system: ActorSystem, ec: ExecutionContext): ActorRef =
-    system.actorOf(props(networkControllerRef, peerManager, settings, featureSerializers))
+    system.actorOf(props(networkControllerRef, peerManager, dnsClientRef, settings, featureSerializers))
 
-  def apply(name: String, networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings,
+  def apply(name: String, networkControllerRef: ActorRef, peerManager: ActorRef, dnsClientRef: ActorRef, settings: NetworkSettings,
             featureSerializers: PeerFeature.Serializers)(implicit system: ActorSystem, ec: ExecutionContext): ActorRef =
-    system.actorOf(props(networkControllerRef, peerManager, settings, featureSerializers), name)
+    system.actorOf(props(networkControllerRef, peerManager, dnsClientRef, settings, featureSerializers), name)
 }

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -48,6 +48,12 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
     val msg = Message[Unit](GetPeersSpec, Right(Unit), None)
     val stn = SendToNetwork(msg, SendToRandom)
     context.system.scheduler.scheduleWithFixedDelay(2.seconds, settings.getPeersInterval, networkControllerRef, stn)
+
+    performFirstDnsSeedersLookup()
+  }
+
+  private def performFirstDnsSeedersLookup(): Unit = {
+    self ! GetNewPeers()
   }
 
   override def receive: Receive = {

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -4,9 +4,8 @@ import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, RegisterMessageSpecs, SendToNetwork}
-import scorex.core.network.PeerSynchronizer.ReceivableMessages.GetNewPeers
+import scorex.core.network.PeerSynchronizer.ReceivableMessages.{GetNewPeers, LookupResponse}
 import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
-import scorex.core.network.dns.strategy.Response.LookupResponse
 import scorex.core.network.dns.strategy.Strategy.LeastNodeQuantity
 import scorex.core.network.message.{GetPeersSpec, Message, MessageSpec, PeersSpec}
 import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddOrUpdatePeer, AddPeerIfEmpty, SeenPeers}
@@ -15,7 +14,7 @@ import scorex.core.settings.NetworkSettings
 import scorex.util.ScorexLogging
 import shapeless.syntax.typeable._
 
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -104,6 +103,8 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 object PeerSynchronizer {
   object ReceivableMessages {
     case class GetNewPeers()
+
+    case class LookupResponse(ipv4Addresses: Seq[InetAddress], ipv6Addresses: Seq[InetAddress])
   }
 }
 

--- a/src/main/scala/scorex/core/network/dns/DnsClient.scala
+++ b/src/main/scala/scorex/core/network/dns/DnsClient.scala
@@ -6,13 +6,13 @@ import scorex.core.network.dns.strategy.LookupStrategy
 import scorex.util.ScorexLogging
 
 class DnsClient(dnsClientParams: DnsClientInput) extends Actor with ScorexLogging {
-  import scorex.core.network.dns.DnsClient.ReceivableMessages.GetDnsSeeds
+  import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
 
   override def receive: Receive =
     dnsLookup orElse nonsense
 
   private def dnsLookup: Receive = {
-    case GetDnsSeeds(strategy: LookupStrategy, dnsClientParams: DnsClientInput) => sender() ! strategy.apply(dnsClientParams)
+    case LookupRequest(strategy: LookupStrategy) => sender() ! strategy.apply(dnsClientParams)
   }
 
   private def nonsense: Receive = {
@@ -23,7 +23,7 @@ class DnsClient(dnsClientParams: DnsClientInput) extends Actor with ScorexLoggin
 
 object DnsClient {
   object ReceivableMessages {
-    case class GetDnsSeeds(s: LookupStrategy, o: DnsClientInput)
+    case class LookupRequest(s: LookupStrategy)
   }
 }
 

--- a/src/main/scala/scorex/core/network/dns/DnsClient.scala
+++ b/src/main/scala/scorex/core/network/dns/DnsClient.scala
@@ -1,0 +1,37 @@
+package scorex.core.network.dns
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import scorex.core.network.dns.model.DnsClientInput
+import scorex.core.network.dns.strategy.LookupStrategy
+import scorex.util.ScorexLogging
+
+class DnsClient(dnsClientParams: DnsClientInput) extends Actor with ScorexLogging {
+  import scorex.core.network.dns.DnsClient.ReceivableMessages.GetDnsSeeds
+
+  override def receive: Receive =
+    dnsLookup orElse nonsense
+
+  private def dnsLookup: Receive = {
+    case GetDnsSeeds(strategy: LookupStrategy, dnsClientParams: DnsClientInput) => sender() ! strategy.apply(dnsClientParams)
+  }
+
+  private def nonsense: Receive = {
+    case nonsense: Any =>
+      log.warn(s"DnsClient: got unexpected input $nonsense")
+  }
+}
+
+object DnsClient {
+  object ReceivableMessages {
+    case class GetDnsSeeds(s: LookupStrategy, o: DnsClientInput)
+  }
+}
+
+object DnsClientRef {
+  def props(params: DnsClientInput): Props = {
+    Props(new DnsClient(params))
+  }
+  def apply(dnsClientParams: DnsClientInput)(implicit system: ActorSystem): ActorRef = {
+    system.actorOf(props(dnsClientParams))
+  }
+}

--- a/src/main/scala/scorex/core/network/dns/DnsClient.scala
+++ b/src/main/scala/scorex/core/network/dns/DnsClient.scala
@@ -6,6 +6,7 @@ import scorex.core.network.dns.strategy.LookupStrategy
 import scorex.util.ScorexLogging
 
 class DnsClient(dnsClientParams: DnsClientInput) extends Actor with ScorexLogging {
+
   import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
 
   override def receive: Receive =
@@ -25,12 +26,18 @@ object DnsClient {
   object ReceivableMessages {
     case class LookupRequest(s: LookupStrategy)
   }
+
+  object Exception {
+    final case class DnsLookupException(private val message: String = "")
+      extends Exception(message)
+  }
 }
 
 object DnsClientRef {
   def props(params: DnsClientInput): Props = {
     Props(new DnsClient(params))
   }
+
   def apply(dnsClientParams: DnsClientInput)(implicit system: ActorSystem): ActorRef = {
     system.actorOf(props(dnsClientParams))
   }

--- a/src/main/scala/scorex/core/network/dns/model/DnsClientInput.scala
+++ b/src/main/scala/scorex/core/network/dns/model/DnsClientInput.scala
@@ -3,11 +3,12 @@ package scorex.core.network.dns.model
 import scorex.core.network.dns.model.DnsClientInput.defaultLookupFunction
 
 import java.net.InetAddress
+import scala.util.Try
 
-case class DnsClientInput(dnsSeeders: Seq[DnsSeederDomain], lookupFunction: DnsSeederDomain => Seq[InetAddress] = defaultLookupFunction)
+case class DnsClientInput(dnsSeeders: Seq[DnsSeederDomain], lookupFunction: DnsSeederDomain => Try[Seq[InetAddress]] = defaultLookupFunction)
 
 object DnsClientInput {
-  def defaultLookupFunction(url: DnsSeederDomain): Seq[InetAddress] = {
-    InetAddress.getAllByName(url.domainName)
+  def defaultLookupFunction(url: DnsSeederDomain): Try[Seq[InetAddress]] = {
+    Try(InetAddress.getAllByName(url.domainName))
   }
 }

--- a/src/main/scala/scorex/core/network/dns/model/DnsClientInput.scala
+++ b/src/main/scala/scorex/core/network/dns/model/DnsClientInput.scala
@@ -1,0 +1,13 @@
+package scorex.core.network.dns.model
+
+import scorex.core.network.dns.model.DnsClientInput.defaultLookupFunction
+
+import java.net.InetAddress
+
+case class DnsClientInput(dnsSeeders: Seq[DnsSeederDomain], lookupFunction: DnsSeederDomain => Seq[InetAddress] = defaultLookupFunction)
+
+object DnsClientInput {
+  def defaultLookupFunction(url: DnsSeederDomain): Seq[InetAddress] = {
+    InetAddress.getAllByName(url.domainName)
+  }
+}

--- a/src/main/scala/scorex/core/network/dns/model/DnsSeederDomain.scala
+++ b/src/main/scala/scorex/core/network/dns/model/DnsSeederDomain.scala
@@ -1,0 +1,10 @@
+package scorex.core.network.dns.model
+
+class DnsSeederDomain(val domainName: String) {
+  private val WEB_DOMAIN_REGEX = "^(((?!\\-))(xn\\-\\-)?[a-z0-9\\-_]{0,61}[a-z0-9]{1,1}\\.)*(xn\\-\\-)?([a-z0-9\\-]{1,61}|[a-z0-9\\-]{1,30})\\.[a-z]{2,}$".r
+
+  domainName match {
+    case e if e.trim.isEmpty || WEB_DOMAIN_REGEX.findFirstMatchIn(e).isEmpty => throw new IllegalArgumentException("Domain name is not well formed")
+    case _ =>
+  }
+}

--- a/src/main/scala/scorex/core/network/dns/strategy/LookupStrategy.scala
+++ b/src/main/scala/scorex/core/network/dns/strategy/LookupStrategy.scala
@@ -1,0 +1,54 @@
+package scorex.core.network.dns.strategy
+
+import scorex.core.network.dns.model.DnsClientInput
+import scorex.core.network.dns.strategy.Response.LookupResponse
+
+import java.net.{Inet4Address, Inet6Address, InetAddress}
+
+trait LookupStrategy {
+  def apply(dnsClientParams: DnsClientInput): LookupResponse
+}
+
+object Strategy {
+  case class LeastNodeQuantity() extends LookupStrategy {
+    private val LEAST_NODE_QUANTITY = 1
+
+    override def apply(dnsClientParams: DnsClientInput): LookupResponse = thresholdNodeQuantity(dnsClientParams, LEAST_NODE_QUANTITY)
+  }
+
+  case class MaxNodeQuantity() extends LookupStrategy {
+    private val MAX_NODE_QUANTITY = Int.MaxValue
+
+    override def apply(dnsClientParams: DnsClientInput): LookupResponse = {
+      thresholdNodeQuantity(dnsClientParams, MAX_NODE_QUANTITY)
+    }
+  }
+
+  case class ThresholdNodeQuantity(nodeThreshold: Int) extends LookupStrategy {
+    override def apply(dnsClientParams: DnsClientInput): LookupResponse = thresholdNodeQuantity(dnsClientParams, nodeThreshold)
+  }
+
+  private def thresholdNodeQuantity(dnsClientParams: DnsClientInput, nodesThreshold: Int): LookupResponse = {
+    if (nodesThreshold <= 0) throw new IllegalArgumentException("The nodes threshold must be greater than 0")
+    val seeders = dnsClientParams.dnsSeeders
+    val lookupFunction = dnsClientParams.lookupFunction
+
+    val (ipv4Addresses, ipv6Addresses) = seeders.foldLeft(Seq[InetAddress]()) { (acc, curr) =>
+      val newElements = if (acc.size < nodesThreshold) {
+        lookupFunction(curr)
+      } else {
+        Seq[InetAddress]()
+      }
+      acc ++ newElements
+    }.partition {
+      case _: Inet4Address => true
+      case _: Inet6Address => false
+    }
+
+    LookupResponse(ipv4Addresses, ipv6Addresses)
+  }
+}
+
+object Response {
+  case class LookupResponse(ipv4Addresses: Seq[InetAddress], ipv6Addresses: Seq[InetAddress])
+}

--- a/src/main/scala/scorex/core/network/dns/strategy/LookupStrategy.scala
+++ b/src/main/scala/scorex/core/network/dns/strategy/LookupStrategy.scala
@@ -5,58 +5,63 @@ import scorex.core.network.dns.DnsClient.Exception.DnsLookupException
 import scorex.core.network.dns.model.DnsClientInput
 
 import java.net.{Inet4Address, Inet6Address, InetAddress}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 trait LookupStrategy {
-  def apply(dnsClientParams: DnsClientInput): LookupResponse
+  def apply(dnsClientParams: DnsClientInput): Try[LookupResponse]
 }
 
 object Strategy {
   case class LeastNodeQuantity() extends LookupStrategy {
     private val LEAST_NODE_QUANTITY = 1
 
-    override def apply(dnsClientParams: DnsClientInput): LookupResponse = thresholdNodeQuantity(dnsClientParams, LEAST_NODE_QUANTITY)
+    override def apply(dnsClientParams: DnsClientInput): Try[LookupResponse] = thresholdNodeQuantity(dnsClientParams, LEAST_NODE_QUANTITY)
   }
 
   case class MaxNodeQuantity() extends LookupStrategy {
     private val MAX_NODE_QUANTITY = Int.MaxValue
 
-    override def apply(dnsClientParams: DnsClientInput): LookupResponse = {
+    override def apply(dnsClientParams: DnsClientInput): Try[LookupResponse] = {
       thresholdNodeQuantity(dnsClientParams, MAX_NODE_QUANTITY)
     }
   }
 
   case class ThresholdNodeQuantity(nodeThreshold: Int) extends LookupStrategy {
-    override def apply(dnsClientParams: DnsClientInput): LookupResponse = thresholdNodeQuantity(dnsClientParams, nodeThreshold)
+    override def apply(dnsClientParams: DnsClientInput): Try[LookupResponse] = thresholdNodeQuantity(dnsClientParams, nodeThreshold)
   }
 
-  private def thresholdNodeQuantity(dnsClientParams: DnsClientInput, nodesThreshold: Int): LookupResponse = {
-    if (nodesThreshold <= 0) throw new IllegalArgumentException("The nodes threshold must be greater than 0")
-    val seeders = dnsClientParams.dnsSeeders
-    val lookupFunction = dnsClientParams.lookupFunction
+  private def thresholdNodeQuantity(dnsClientParams: DnsClientInput, nodesThreshold: Int): Try[LookupResponse] = {
+    if (nodesThreshold <= 0) {
+      Failure(new IllegalArgumentException("The nodes threshold must be greater than 0"))
+    } else {
+      val seeders = dnsClientParams.dnsSeeders
+      val lookupFunction = dnsClientParams.lookupFunction
 
-    val exceptionMessages = Seq[String]()
+      val exceptionMessages = Seq[String]()
 
-    val (ipv4Addresses, ipv6Addresses) = seeders.foldLeft(Seq[InetAddress]()) { (acc, curr) =>
-      val newElements = if (acc.size < nodesThreshold) {
-        lookupFunction(curr) match {
-          case Success(value) => value
-          case Failure(exception) =>
-            exceptionMessages ++ exception.getMessage
-            Seq[InetAddress]()
+      val (ipv4Addresses, ipv6Addresses) = seeders.foldLeft(Seq[InetAddress]()) { (acc, curr) =>
+        val newElements = if (acc.size < nodesThreshold) {
+          lookupFunction(curr) match {
+            case Success(value) => value
+            case Failure(exception) =>
+              exceptionMessages ++ exception.getMessage
+              Seq[InetAddress]()
+          }
+        } else {
+          Seq[InetAddress]()
         }
-      } else {
-        Seq[InetAddress]()
+
+        acc ++ newElements
+      }.partition {
+        case _: Inet4Address => true
+        case _: Inet6Address => false
       }
 
-      acc ++ newElements
-    }.partition {
-      case _: Inet4Address => true
-      case _: Inet6Address => false
+      if (ipv4Addresses.isEmpty && ipv6Addresses.isEmpty) {
+        Failure(DnsLookupException("All dns lookups failed: " + exceptionMessages.mkString(", ")))
+      } else {
+        Success(LookupResponse(ipv4Addresses, ipv6Addresses))
+      }
     }
-
-    if (ipv4Addresses.isEmpty && ipv6Addresses.isEmpty) throw DnsLookupException("All dns lookups failed: " + exceptionMessages.mkString(", "))
-
-    LookupResponse(ipv4Addresses, ipv6Addresses)
   }
 }

--- a/src/main/scala/scorex/core/network/peer/PeerManager.scala
+++ b/src/main/scala/scorex/core/network/peer/PeerManager.scala
@@ -1,9 +1,9 @@
 package scorex.core.network.peer
 
 import java.net.{InetAddress, InetSocketAddress}
-
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import scorex.core.app.ScorexContext
+import scorex.core.network.NetworkController.ReceivableMessages.EmptyPeerDatabase
 import scorex.core.network._
 import scorex.core.settings.ScorexSettings
 import scorex.core.utils.NetworkUtils
@@ -122,8 +122,6 @@ object PeerManager {
     case class AddPeerIfEmpty(data: PeerSpec)
 
     case class RemovePeer(address: InetSocketAddress)
-
-    case class EmptyPeerDatabase()
 
     /**
       * Message to get peers from known peers map filtered by `choose` function

--- a/src/main/scala/scorex/core/settings/Settings.scala
+++ b/src/main/scala/scorex/core/settings/Settings.scala
@@ -2,10 +2,10 @@ package scorex.core.settings
 
 import java.io.File
 import java.net.InetSocketAddress
-
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import scorex.core.network.dns.model.DnsSeederDomain
 import scorex.core.network.message.Message
 import scorex.core.utils.NetworkTimeProviderSettings
 import scorex.util.ScorexLogging
@@ -21,6 +21,7 @@ case class NetworkSettings(nodeName: String,
                            addedMaxDelay: Option[FiniteDuration],
                            localOnly: Boolean,
                            knownPeers: Seq[InetSocketAddress],
+                           knownSeeders: Seq[DnsSeederDomain],
                            bindAddress: InetSocketAddress,
                            maxConnections: Int,
                            connectionTimeout: FiniteDuration,

--- a/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
+++ b/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
@@ -6,15 +6,16 @@ import akka.util.Timeout
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers.be
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import scorex.core.network.PeerSynchronizer.ReceivableMessages.LookupResponse
 import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
 import scorex.core.network.dns.model.{DnsClientInput, DnsSeederDomain}
-import scorex.core.network.dns.strategy.Response.LookupResponse
 import scorex.core.network.dns.strategy.Strategy.{LeastNodeQuantity, MaxNodeQuantity, ThresholdNodeQuantity}
 
 import java.net.InetAddress
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
+import scala.util.Try
 
 class DnsClientSpec extends AnyFlatSpec {
   private val fakeURLOne = new DnsSeederDomain("fake-url.com")
@@ -28,10 +29,12 @@ class DnsClientSpec extends AnyFlatSpec {
   private val fakeURLThree = new DnsSeederDomain("fake-url3.com")
   private val fakeIpSeqThree = Seq(InetAddress.getByName("127.0.1.1"), InetAddress.getByName("127.0.1.2"))
 
+  private val badURL = new DnsSeederDomain("bad-url.com")
+
   private val mockLookupFunction = (url: DnsSeederDomain) => url match {
-    case `fakeURLOne` => fakeIpSeqOne
-    case `fakeURLTwo` => fakeIpSeqTwo
-    case `fakeURLThree` => fakeIpSeqThree
+    case `fakeURLOne` => Try(fakeIpSeqOne)
+    case `fakeURLTwo` => Try(fakeIpSeqTwo)
+    case `fakeURLThree` => Try(fakeIpSeqThree)
     case _ => throw new IllegalArgumentException("Unexpected url in test")
   }
 

--- a/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
+++ b/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
@@ -1,0 +1,121 @@
+package scorex.core.network.dns
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.pattern.ask
+import akka.util.Timeout
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers.be
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import scorex.core.network.dns.DnsClient.ReceivableMessages.GetDnsSeeds
+import scorex.core.network.dns.model.{DnsClientInput, DnsSeederDomain}
+import scorex.core.network.dns.strategy.Response.LookupResponse
+import scorex.core.network.dns.strategy.Strategy.{LeastNodeQuantity, MaxNodeQuantity, ThresholdNodeQuantity}
+
+import java.net.InetAddress
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
+class DnsClientSpec extends AnyFlatSpec {
+  private val fakeURLOne = new DnsSeederDomain("fake-url.com")
+  private val fakeIpSeqOne = Seq(
+    InetAddress.getByName("127.0.0.1"), InetAddress.getByName("127.0.0.2"), InetAddress.getByName("127.0.0.3"), InetAddress.getByName("127.0.0.4")
+  )
+
+  private val fakeURLTwo = new DnsSeederDomain("fake-url2.com")
+  private val fakeIpSeqTwo = Seq(InetAddress.getByName("127.0.1.1"))
+
+  private val fakeURLThree = new DnsSeederDomain("fake-url3.com")
+  private val fakeIpSeqThree = Seq(InetAddress.getByName("127.0.1.1"), InetAddress.getByName("127.0.1.2"))
+
+  private val mockLookupFunction = (url: DnsSeederDomain) => url match {
+    case `fakeURLOne` => fakeIpSeqOne
+    case `fakeURLTwo` => fakeIpSeqTwo
+    case `fakeURLThree` => fakeIpSeqThree
+    case _ => throw new IllegalArgumentException("Unexpected url in test")
+  }
+
+  "A DnsClient" should "reply with the least number of IPs" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val timeout: Timeout = Timeout(5 seconds)
+
+    val dnsClientParams = DnsClientInput(
+      Seq(fakeURLOne, fakeURLTwo, fakeURLThree),
+      mockLookupFunction
+    )
+
+    val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
+
+    // Act
+    val futureResponse = (dnsClient ? GetDnsSeeds(LeastNodeQuantity(), dnsClientParams)).mapTo[LookupResponse]
+    val response: LookupResponse = Await.result(futureResponse, 5 seconds)
+
+    // Assert
+    response.ipv4Addresses.size should be(fakeIpSeqOne.size)
+  }
+
+  "A DnsClient" should "reply with the max number of IPs" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val timeout: Timeout = Timeout(5 seconds)
+
+    val dnsClientParams = DnsClientInput(
+      Seq(fakeURLOne, fakeURLTwo, fakeURLThree),
+      mockLookupFunction
+    )
+
+    val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
+
+    // Act
+    val futureResponse = (dnsClient ? GetDnsSeeds(MaxNodeQuantity(), dnsClientParams)).mapTo[LookupResponse]
+    val response: LookupResponse = Await.result(futureResponse, 5 seconds)
+
+    // Assert
+    response.ipv4Addresses.size should be(fakeIpSeqOne.size + fakeIpSeqTwo.size + fakeIpSeqThree.size)
+  }
+
+  "A DnsClient" should "reply with a threshold number of IPs" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val timeout: Timeout = Timeout(5 seconds)
+
+    val nodesThreshold = 3
+
+    val dnsClientParams = DnsClientInput(
+      Seq(fakeURLOne, fakeURLTwo, fakeURLThree),
+      mockLookupFunction
+    )
+
+    val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
+
+    // Act
+    val futureResponse = (dnsClient ? GetDnsSeeds(ThresholdNodeQuantity(nodesThreshold), dnsClientParams)).mapTo[LookupResponse]
+    val response: LookupResponse = Await.result(futureResponse, 5 seconds)
+
+    // Assert
+    response.ipv4Addresses.size should (be <= fakeIpSeqOne.size and be >= nodesThreshold)
+  }
+
+  "A DnsClient" should "reply with a threshold number of IPs bis" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val timeout: Timeout = Timeout(5 seconds)
+
+    val nodesThreshold = 5
+
+    val dnsClientParams = DnsClientInput(
+      Seq(fakeURLOne, fakeURLTwo, fakeURLThree),
+      mockLookupFunction
+    )
+
+    val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
+
+    // Act
+    val futureResponse = (dnsClient ? GetDnsSeeds(ThresholdNodeQuantity(nodesThreshold), dnsClientParams)).mapTo[LookupResponse]
+    val response: LookupResponse = Await.result(futureResponse, 5 seconds)
+
+    // Assert
+    response.ipv4Addresses.size should be (fakeIpSeqOne.size + fakeIpSeqTwo.size)
+  }
+}

--- a/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
+++ b/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
@@ -29,8 +29,6 @@ class DnsClientSpec extends AnyFlatSpec {
   private val fakeURLThree = new DnsSeederDomain("fake-url3.com")
   private val fakeIpSeqThree = Seq(InetAddress.getByName("127.0.1.1"), InetAddress.getByName("127.0.1.2"))
 
-  private val badURL = new DnsSeederDomain("bad-url.com")
-
   private val mockLookupFunction = (url: DnsSeederDomain) => url match {
     case `fakeURLOne` => Try(fakeIpSeqOne)
     case `fakeURLTwo` => Try(fakeIpSeqTwo)
@@ -56,6 +54,8 @@ class DnsClientSpec extends AnyFlatSpec {
 
     // Assert
     response.ipv4Addresses.size should be(fakeIpSeqOne.size)
+
+    system.terminate()
   }
 
   "A DnsClient" should "reply with the max number of IPs" in {
@@ -76,6 +76,8 @@ class DnsClientSpec extends AnyFlatSpec {
 
     // Assert
     response.ipv4Addresses.size should be(fakeIpSeqOne.size + fakeIpSeqTwo.size + fakeIpSeqThree.size)
+
+    system.terminate()
   }
 
   "A DnsClient" should "reply with a threshold number of IPs" in {
@@ -98,6 +100,8 @@ class DnsClientSpec extends AnyFlatSpec {
 
     // Assert
     response.ipv4Addresses.size should (be <= fakeIpSeqOne.size and be >= nodesThreshold)
+
+    system.terminate()
   }
 
   "A DnsClient" should "reply with a threshold number of IPs bis" in {
@@ -119,6 +123,8 @@ class DnsClientSpec extends AnyFlatSpec {
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert
-    response.ipv4Addresses.size should be (fakeIpSeqOne.size + fakeIpSeqTwo.size)
+    response.ipv4Addresses.size should be(fakeIpSeqOne.size + fakeIpSeqTwo.size)
+
+    system.terminate()
   }
 }

--- a/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
+++ b/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers.be
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import scorex.core.network.dns.DnsClient.ReceivableMessages.GetDnsSeeds
+import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
 import scorex.core.network.dns.model.{DnsClientInput, DnsSeederDomain}
 import scorex.core.network.dns.strategy.Response.LookupResponse
 import scorex.core.network.dns.strategy.Strategy.{LeastNodeQuantity, MaxNodeQuantity, ThresholdNodeQuantity}
@@ -48,7 +48,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(LeastNodeQuantity(), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(LeastNodeQuantity())).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert
@@ -68,7 +68,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(MaxNodeQuantity(), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(MaxNodeQuantity())).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert
@@ -90,7 +90,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(ThresholdNodeQuantity(nodesThreshold), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(ThresholdNodeQuantity(nodesThreshold))).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert
@@ -112,7 +112,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(ThresholdNodeQuantity(nodesThreshold), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(ThresholdNodeQuantity(nodesThreshold))).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert

--- a/src/test/scala/scorex/core/network/peer/PeerManagerSpec.scala
+++ b/src/test/scala/scorex/core/network/peer/PeerManagerSpec.scala
@@ -3,7 +3,8 @@ package scorex.core.network.peer
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.TestProbe
 import scorex.core.app.ScorexContext
-import scorex.core.network.peer.PeerManager.ReceivableMessages.{EmptyPeerDatabase, RemovePeer}
+import scorex.core.network.NetworkController.ReceivableMessages.EmptyPeerDatabase
+import scorex.core.network.peer.PeerManager.ReceivableMessages.RemovePeer
 import scorex.network.NetworkTests
 
 import java.net.InetSocketAddress

--- a/src/test/scala/scorex/core/utils/DnsSeederDomainSpec.scala
+++ b/src/test/scala/scorex/core/utils/DnsSeederDomainSpec.scala
@@ -1,0 +1,32 @@
+package scorex.core.utils
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers.be
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import scorex.core.network.dns.model.DnsSeederDomain
+
+class DnsSeederDomainSpec extends AnyFlatSpec {
+  "A DnsSeederDomain" should "be initialized correctly" in {
+    // Arrange
+    val correctDomainNameSeq = Seq("domain-test.com", "domain.sub-domain.global", "this_is_a_domain.test.dom.horizen", "a.b.c.d.e.f.g.uk.co")
+
+    // Act
+    val webNameSeq = correctDomainNameSeq.map(domain => new DnsSeederDomain(domain))
+
+    // Assert
+    for ((domainString, webName) <- correctDomainNameSeq zip webNameSeq) {
+      webName.domainName should be(domainString)
+    }
+  }
+
+  "A DnsSeederDomain" should "throw and IllegalArgumentException" in {
+    // Arrange
+    val correctDomainNameSeq = Seq("domain-test.com.", "", "     ", ".bad-web-domain.com", "test,domain.global")
+    val createDnsSeederDomain = (domain: String) => new DnsSeederDomain(domain)
+
+    // Act & Assert
+    correctDomainNameSeq.foreach(domain => assertThrows[IllegalArgumentException] {
+      createDnsSeederDomain(domain)
+    })
+  }
+}

--- a/src/test/scala/scorex/flow/DnsLookupFlow.scala
+++ b/src/test/scala/scorex/flow/DnsLookupFlow.scala
@@ -1,0 +1,94 @@
+package scorex.flow
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.io.Tcp.{Bind, Bound, Message => _}
+import akka.testkit.TestProbe
+import scorex.core.app.ScorexContext
+import scorex.core.network._
+import scorex.core.network.dns.DnsClientRef
+import scorex.core.network.dns.model.{DnsClientInput, DnsSeederDomain}
+import scorex.core.network.message._
+import scorex.core.network.peer.PeerManager.ReceivableMessages.{EmptyPeerDatabase, GetAllPeers}
+import scorex.core.network.peer._
+import scorex.core.settings.ScorexSettings
+import scorex.core.utils.LocalTimeProvider
+import scorex.network.NetworkTests
+
+import java.net.{InetAddress, InetSocketAddress}
+
+class DnsLookupFlow extends NetworkTests {
+  type Data = Map[InetSocketAddress, PeerInfo]
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  private val fakeURLOne = new DnsSeederDomain("fake-url.com")
+  private val fakeIpSeqOne = Seq(
+    InetAddress.getByName("127.0.0.1"), InetAddress.getByName("127.0.0.2"), InetAddress.getByName("127.0.0.3"), InetAddress.getByName("127.0.0.4")
+  )
+
+  private val fakeURLTwo = new DnsSeederDomain("fake-url2.com")
+  private val fakeIpSeqTwo = Seq(InetAddress.getByName("127.0.1.1"))
+
+  private val fakeURLThree = new DnsSeederDomain("fake-url3.com")
+  private val fakeIpSeqThree = Seq(InetAddress.getByName("127.0.1.1"), InetAddress.getByName("127.0.1.2"))
+
+  private val mockLookupFunction = (url: DnsSeederDomain) => url match {
+    case `fakeURLOne` => fakeIpSeqOne
+    case `fakeURLTwo` => fakeIpSeqTwo
+    case `fakeURLThree` => fakeIpSeqThree
+    case _ => throw new IllegalArgumentException("Unexpected url in test")
+  }
+  private val featureSerializers = Map(LocalAddressPeerFeature.featureId -> LocalAddressPeerFeatureSerializer)
+
+  it should "perform a dns lookup and fill the internal peer database with new received IPs" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val tcpManagerProbe = TestProbe()
+
+    val probe = TestProbe("probe")(system)
+    implicit val defaultSender: ActorRef = probe.testActor
+
+    val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
+    val scorexSettings = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
+    val (networkControllerRef, peerManager) = createNetworkController(scorexSettings, tcpManagerProbe)
+
+    // Act
+    networkControllerRef ! EmptyPeerDatabase()
+
+    // Assert
+    Thread.sleep(1000)
+    peerManager ! GetAllPeers
+    val data = probe.expectMsgClass(classOf[Data])
+    data.size should be(fakeIpSeqOne.size)
+
+    system.terminate()
+  }
+
+  private def createNetworkController(settings: ScorexSettings, tcpManagerProbe: TestProbe, upnp: Option[UPnPGateway] = None)(implicit system: ActorSystem) = {
+    val timeProvider = LocalTimeProvider
+    val externalAddr = settings.network.declaredAddress
+      .orElse(upnp.map(u => new InetSocketAddress(u.externalAddress, settings.network.bindAddress.getPort)))
+
+    val peersSpec: PeersSpec = new PeersSpec(featureSerializers, settings.network.maxPeerSpecObjects)
+    val messageSpecs = Seq(GetPeersSpec, peersSpec)
+    val scorexContext = ScorexContext(messageSpecs, Seq.empty, upnp, timeProvider, externalAddr)
+
+    val dnsClientInput = new DnsClientInput(Seq(fakeURLOne, fakeURLTwo), mockLookupFunction)
+    val dnsClientRef = DnsClientRef(dnsClientInput)
+
+    val peerManagerRef = PeerManagerRef(settings, scorexContext)
+
+    val networkControllerRef: ActorRef = NetworkControllerRef(
+      "networkController", settings.network,
+      peerManagerRef, scorexContext, tcpManagerProbe.testActor)
+
+    val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer",
+      networkControllerRef, peerManagerRef, dnsClientRef, settings.network, featureSerializers)
+
+    tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))
+
+    tcpManagerProbe.send(networkControllerRef, Bound(settings.network.bindAddress))
+    (networkControllerRef, peerManagerRef)
+  }
+}

--- a/src/test/scala/scorex/flow/DnsLookupFlow.scala
+++ b/src/test/scala/scorex/flow/DnsLookupFlow.scala
@@ -4,17 +4,19 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.io.Tcp.{Bind, Bound, Message => _}
 import akka.testkit.TestProbe
 import scorex.core.app.ScorexContext
+import scorex.core.network.NetworkController.ReceivableMessages.EmptyPeerDatabase
 import scorex.core.network._
 import scorex.core.network.dns.DnsClientRef
 import scorex.core.network.dns.model.{DnsClientInput, DnsSeederDomain}
 import scorex.core.network.message._
-import scorex.core.network.peer.PeerManager.ReceivableMessages.{EmptyPeerDatabase, GetAllPeers}
+import scorex.core.network.peer.PeerManager.ReceivableMessages.GetAllPeers
 import scorex.core.network.peer._
 import scorex.core.settings.ScorexSettings
 import scorex.core.utils.LocalTimeProvider
 import scorex.network.NetworkTests
 
 import java.net.{InetAddress, InetSocketAddress}
+import scala.util.Try
 
 class DnsLookupFlow extends NetworkTests {
   type Data = Map[InetSocketAddress, PeerInfo]
@@ -33,9 +35,9 @@ class DnsLookupFlow extends NetworkTests {
   private val fakeIpSeqThree = Seq(InetAddress.getByName("127.0.1.1"), InetAddress.getByName("127.0.1.2"))
 
   private val mockLookupFunction = (url: DnsSeederDomain) => url match {
-    case `fakeURLOne` => fakeIpSeqOne
-    case `fakeURLTwo` => fakeIpSeqTwo
-    case `fakeURLThree` => fakeIpSeqThree
+    case `fakeURLOne` => Try(fakeIpSeqOne)
+    case `fakeURLTwo` => Try(fakeIpSeqTwo)
+    case `fakeURLThree` => Try(fakeIpSeqThree)
     case _ => throw new IllegalArgumentException("Unexpected url in test")
   }
   private val featureSerializers = Map(LocalAddressPeerFeature.featureId -> LocalAddressPeerFeatureSerializer)

--- a/src/test/scala/scorex/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/network/NetworkControllerSpec.scala
@@ -11,11 +11,13 @@ import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.TryValues._
 import org.scalatest.matchers.should.Matchers
-import scorex.core.app.{Version, ScorexContext}
+import scorex.core.app.{ScorexContext, Version}
 import scorex.core.network.NetworkController.ReceivableMessages.{GetConnectedPeers, GetPeersStatus}
 import scorex.core.network._
+import scorex.core.network.dns.DnsClientRef
+import scorex.core.network.dns.model.DnsClientInput
 import scorex.core.network.message.{PeersSpec, _}
-import scorex.core.network.peer.{LocalAddressPeerFeature, PeerManagerRef, LocalAddressPeerFeatureSerializer, PeersStatus, SessionIdPeerFeature}
+import scorex.core.network.peer.{LocalAddressPeerFeature, LocalAddressPeerFeatureSerializer, PeerManagerRef, PeersStatus, SessionIdPeerFeature}
 import scorex.core.settings.ScorexSettings
 import scorex.core.utils.LocalTimeProvider
 
@@ -322,6 +324,9 @@ class NetworkControllerSpec extends NetworkTests {
     val messageSpecs = Seq(GetPeersSpec, peersSpec)
     val scorexContext = ScorexContext(messageSpecs, Seq.empty, upnp, timeProvider, externalAddr)
 
+    val dnsClientInput = new DnsClientInput(Seq())
+    val dnsClient = DnsClientRef(dnsClientInput)
+
     val peerManagerRef = PeerManagerRef(settings, scorexContext)
 
     val networkControllerRef: ActorRef = NetworkControllerRef(
@@ -329,7 +334,7 @@ class NetworkControllerSpec extends NetworkTests {
       peerManagerRef, scorexContext, tcpManagerProbe.testActor)
 
     val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer",
-      networkControllerRef, peerManagerRef, settings.network, featureSerializers)
+      networkControllerRef, peerManagerRef, dnsClient, settings.network, featureSerializers)
 
 
     tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))


### PR DESCRIPTION
Create a new actor responsible for DNS seeder lookups (DnsClient) and the strategies it will be collecting IP addresses with:

- it will receive a GetDnsSeeds message with a strategy and return to the sender the IP addresses based on that strategy;
- the strategies can be
  - get as many IP addresses as possible;
  - get the minimum number of IP addresses (just return the collection of IPs returned by the first DNS seeder);
  - get at least X number of IP addresses;
- add a new network configuration called knownSeeders;
- unit tests-