### PR TITLE
Sdk 143 - DnsClient lookup flow implementation

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -105,6 +105,9 @@ scorex {
     # List of IP addresses of well known nodes.
     knownPeers = []
 
+    # List of known DNS seeder.
+    knownSeeders = []
+
     # Interval between GetPeers messages to be send by our node to a random one
     getPeersInterval = 2m
 

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -1,7 +1,5 @@
 package scorex.core.network
 
-import java.net._
-
 import akka.actor._
 import akka.io.Tcp._
 import akka.io.{IO, Tcp}
@@ -9,15 +7,17 @@ import akka.pattern.ask
 import akka.util.Timeout
 import scorex.core.app.{ScorexContext, Version}
 import scorex.core.network.NodeViewSynchronizer.ReceivableMessages.{DisconnectedPeer, HandshakedPeer}
+import scorex.core.network.PeerSynchronizer.ReceivableMessages.GetNewPeers
 import scorex.core.network.message.Message.MessageCode
 import scorex.core.network.message.{Message, MessageSpec}
 import scorex.core.network.peer.PeerManager.ReceivableMessages._
-import scorex.core.network.peer.{LocalAddressPeerFeature, PeerInfo, PeerManager, PeersStatus, PenaltyType, SessionIdPeerFeature}
+import scorex.core.network.peer._
 import scorex.core.settings.NetworkSettings
 import scorex.core.utils.TimeProvider.Time
 import scorex.core.utils.{NetworkUtils, TimeProvider}
 import scorex.util.ScorexLogging
 
+import java.net._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.{existentials, postfixOps}
@@ -139,6 +139,9 @@ class NetworkController(settings: NetworkSettings,
 
     case Blacklisted(peerAddress) =>
       closeConnection(peerAddress)
+
+    case EmptyPeerDatabase() =>
+      context.system.eventStream.publish(GetNewPeers())
   }
 
   private def connectionEvents: Receive = {

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -4,13 +4,18 @@ import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, RegisterMessageSpecs, SendToNetwork}
+import scorex.core.network.PeerSynchronizer.ReceivableMessages.GetNewPeers
+import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
+import scorex.core.network.dns.strategy.Response.LookupResponse
+import scorex.core.network.dns.strategy.Strategy.LeastNodeQuantity
 import scorex.core.network.message.{GetPeersSpec, Message, MessageSpec, PeersSpec}
+import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddOrUpdatePeer, AddPeerIfEmpty, SeenPeers}
 import scorex.core.network.peer.{PeerInfo, PenaltyType}
-import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddPeerIfEmpty, SeenPeers}
 import scorex.core.settings.NetworkSettings
 import scorex.util.ScorexLogging
 import shapeless.syntax.typeable._
 
+import java.net.InetSocketAddress
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -19,6 +24,7 @@ import scala.concurrent.duration._
   */
 class PeerSynchronizer(val networkControllerRef: ActorRef,
                        peerManager: ActorRef,
+                       dnsClientRef: ActorRef,
                        settings: NetworkSettings,
                        featureSerializers: PeerFeature.Serializers)
                       (implicit ec: ExecutionContext) extends Actor with Synchronizer with ScorexLogging {
@@ -38,6 +44,8 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 
     networkControllerRef ! RegisterMessageSpecs(Seq(GetPeersSpec, peersSpec), self)
 
+    context.system.eventStream.subscribe(self, classOf[GetNewPeers])
+
     val msg = Message[Unit](GetPeersSpec, Right(Unit), None)
     val stn = SendToNetwork(msg, SendToRandom)
     context.system.scheduler.scheduleWithFixedDelay(2.seconds, settings.getPeersInterval, networkControllerRef, stn)
@@ -47,6 +55,17 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 
     // data received from a remote peer
     case Message(spec, Left(msgBytes), Some(source)) => parseAndHandle(spec, msgBytes, source)
+
+    // TODO: it could be a good idea to pass the peers left in the db or some other criteria
+    // TODO: to decide the lookup strategy
+    case GetNewPeers() =>
+      dnsClientRef ! LookupRequest(LeastNodeQuantity())
+
+    case LookupResponse(ipv4Addresses, _) =>
+      val defaultPort = settings.bindAddress.getPort
+      ipv4Addresses.foreach(
+        address => peerManager ! AddOrUpdatePeer(PeerInfo.fromAddress(new InetSocketAddress(address, defaultPort)))
+      )
 
     // fall-through method for reporting unhandled messages
     case nonsense: Any => log.warn(s"PeerSynchronizer: got unexpected input $nonsense from ${sender()}")
@@ -82,16 +101,22 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
   }
 }
 
+object PeerSynchronizer {
+  object ReceivableMessages {
+    case class GetNewPeers()
+  }
+}
+
 object PeerSynchronizerRef {
-  def props(networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings,
+  def props(networkControllerRef: ActorRef, peerManager: ActorRef, dnsClientRef: ActorRef, settings: NetworkSettings,
             featureSerializers: PeerFeature.Serializers)(implicit ec: ExecutionContext): Props =
-    Props(new PeerSynchronizer(networkControllerRef, peerManager, settings, featureSerializers))
+    Props(new PeerSynchronizer(networkControllerRef, peerManager, dnsClientRef, settings, featureSerializers))
 
-  def apply(networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings,
+  def apply(networkControllerRef: ActorRef, peerManager: ActorRef, dnsClientRef: ActorRef, settings: NetworkSettings,
             featureSerializers: PeerFeature.Serializers)(implicit system: ActorSystem, ec: ExecutionContext): ActorRef =
-    system.actorOf(props(networkControllerRef, peerManager, settings, featureSerializers))
+    system.actorOf(props(networkControllerRef, peerManager, dnsClientRef, settings, featureSerializers))
 
-  def apply(name: String, networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings,
+  def apply(name: String, networkControllerRef: ActorRef, peerManager: ActorRef, dnsClientRef: ActorRef, settings: NetworkSettings,
             featureSerializers: PeerFeature.Serializers)(implicit system: ActorSystem, ec: ExecutionContext): ActorRef =
-    system.actorOf(props(networkControllerRef, peerManager, settings, featureSerializers), name)
+    system.actorOf(props(networkControllerRef, peerManager, dnsClientRef, settings, featureSerializers), name)
 }

--- a/src/main/scala/scorex/core/network/dns/DnsClient.scala
+++ b/src/main/scala/scorex/core/network/dns/DnsClient.scala
@@ -6,13 +6,13 @@ import scorex.core.network.dns.strategy.LookupStrategy
 import scorex.util.ScorexLogging
 
 class DnsClient(dnsClientParams: DnsClientInput) extends Actor with ScorexLogging {
-  import scorex.core.network.dns.DnsClient.ReceivableMessages.GetDnsSeeds
+  import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
 
   override def receive: Receive =
     dnsLookup orElse nonsense
 
   private def dnsLookup: Receive = {
-    case GetDnsSeeds(strategy: LookupStrategy, dnsClientParams: DnsClientInput) => sender() ! strategy.apply(dnsClientParams)
+    case LookupRequest(strategy: LookupStrategy) => sender() ! strategy.apply(dnsClientParams)
   }
 
   private def nonsense: Receive = {
@@ -23,7 +23,7 @@ class DnsClient(dnsClientParams: DnsClientInput) extends Actor with ScorexLoggin
 
 object DnsClient {
   object ReceivableMessages {
-    case class GetDnsSeeds(s: LookupStrategy, o: DnsClientInput)
+    case class LookupRequest(s: LookupStrategy)
   }
 }
 

--- a/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
+++ b/src/test/scala/scorex/core/network/dns/DnsClientSpec.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers.be
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import scorex.core.network.dns.DnsClient.ReceivableMessages.GetDnsSeeds
+import scorex.core.network.dns.DnsClient.ReceivableMessages.LookupRequest
 import scorex.core.network.dns.model.{DnsClientInput, DnsSeederDomain}
 import scorex.core.network.dns.strategy.Response.LookupResponse
 import scorex.core.network.dns.strategy.Strategy.{LeastNodeQuantity, MaxNodeQuantity, ThresholdNodeQuantity}
@@ -48,7 +48,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(LeastNodeQuantity(), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(LeastNodeQuantity())).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert
@@ -68,7 +68,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(MaxNodeQuantity(), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(MaxNodeQuantity())).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert
@@ -90,7 +90,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(ThresholdNodeQuantity(nodesThreshold), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(ThresholdNodeQuantity(nodesThreshold))).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert
@@ -112,7 +112,7 @@ class DnsClientSpec extends AnyFlatSpec {
     val dnsClient: ActorRef = DnsClientRef(dnsClientParams)
 
     // Act
-    val futureResponse = (dnsClient ? GetDnsSeeds(ThresholdNodeQuantity(nodesThreshold), dnsClientParams)).mapTo[LookupResponse]
+    val futureResponse = (dnsClient ? LookupRequest(ThresholdNodeQuantity(nodesThreshold))).mapTo[LookupResponse]
     val response: LookupResponse = Await.result(futureResponse, 5 seconds)
 
     // Assert

--- a/src/test/scala/scorex/flow/DnsLookupFlow.scala
+++ b/src/test/scala/scorex/flow/DnsLookupFlow.scala
@@ -1,0 +1,94 @@
+package scorex.flow
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.io.Tcp.{Bind, Bound, Message => _}
+import akka.testkit.TestProbe
+import scorex.core.app.ScorexContext
+import scorex.core.network._
+import scorex.core.network.dns.DnsClientRef
+import scorex.core.network.dns.model.{DnsClientInput, DnsSeederDomain}
+import scorex.core.network.message._
+import scorex.core.network.peer.PeerManager.ReceivableMessages.{EmptyPeerDatabase, GetAllPeers}
+import scorex.core.network.peer._
+import scorex.core.settings.ScorexSettings
+import scorex.core.utils.LocalTimeProvider
+import scorex.network.NetworkTests
+
+import java.net.{InetAddress, InetSocketAddress}
+
+class DnsLookupFlow extends NetworkTests {
+  type Data = Map[InetSocketAddress, PeerInfo]
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  private val fakeURLOne = new DnsSeederDomain("fake-url.com")
+  private val fakeIpSeqOne = Seq(
+    InetAddress.getByName("127.0.0.1"), InetAddress.getByName("127.0.0.2"), InetAddress.getByName("127.0.0.3"), InetAddress.getByName("127.0.0.4")
+  )
+
+  private val fakeURLTwo = new DnsSeederDomain("fake-url2.com")
+  private val fakeIpSeqTwo = Seq(InetAddress.getByName("127.0.1.1"))
+
+  private val fakeURLThree = new DnsSeederDomain("fake-url3.com")
+  private val fakeIpSeqThree = Seq(InetAddress.getByName("127.0.1.1"), InetAddress.getByName("127.0.1.2"))
+
+  private val mockLookupFunction = (url: DnsSeederDomain) => url match {
+    case `fakeURLOne` => fakeIpSeqOne
+    case `fakeURLTwo` => fakeIpSeqTwo
+    case `fakeURLThree` => fakeIpSeqThree
+    case _ => throw new IllegalArgumentException("Unexpected url in test")
+  }
+  private val featureSerializers = Map(LocalAddressPeerFeature.featureId -> LocalAddressPeerFeatureSerializer)
+
+  it should "perform a dns lookup and fill the internal peer database with new received IPs" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val tcpManagerProbe = TestProbe()
+
+    val probe = TestProbe("probe")(system)
+    implicit val defaultSender: ActorRef = probe.testActor
+
+    val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
+    val scorexSettings = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
+    val (networkControllerRef, peerManager) = createNetworkController(scorexSettings, tcpManagerProbe)
+
+    // Act
+    networkControllerRef ! EmptyPeerDatabase()
+
+    // Assert
+    Thread.sleep(1000)
+    peerManager ! GetAllPeers
+    val data = probe.expectMsgClass(classOf[Data])
+    data.size should be(fakeIpSeqOne.size)
+
+    system.terminate()
+  }
+
+  private def createNetworkController(settings: ScorexSettings, tcpManagerProbe: TestProbe, upnp: Option[UPnPGateway] = None)(implicit system: ActorSystem) = {
+    val timeProvider = LocalTimeProvider
+    val externalAddr = settings.network.declaredAddress
+      .orElse(upnp.map(u => new InetSocketAddress(u.externalAddress, settings.network.bindAddress.getPort)))
+
+    val peersSpec: PeersSpec = new PeersSpec(featureSerializers, settings.network.maxPeerSpecObjects)
+    val messageSpecs = Seq(GetPeersSpec, peersSpec)
+    val scorexContext = ScorexContext(messageSpecs, Seq.empty, upnp, timeProvider, externalAddr)
+
+    val dnsClientInput = new DnsClientInput(Seq(fakeURLOne, fakeURLTwo), mockLookupFunction)
+    val dnsClientRef = DnsClientRef(dnsClientInput)
+
+    val peerManagerRef = PeerManagerRef(settings, scorexContext)
+
+    val networkControllerRef: ActorRef = NetworkControllerRef(
+      "networkController", settings.network,
+      peerManagerRef, scorexContext, tcpManagerProbe.testActor)
+
+    val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer",
+      networkControllerRef, peerManagerRef, dnsClientRef, settings.network, featureSerializers)
+
+    tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))
+
+    tcpManagerProbe.send(networkControllerRef, Bound(settings.network.bindAddress))
+    (networkControllerRef, peerManagerRef)
+  }
+}

--- a/src/test/scala/scorex/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/network/NetworkControllerSpec.scala
@@ -11,11 +11,13 @@ import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.TryValues._
 import org.scalatest.matchers.should.Matchers
-import scorex.core.app.{Version, ScorexContext}
+import scorex.core.app.{ScorexContext, Version}
 import scorex.core.network.NetworkController.ReceivableMessages.{GetConnectedPeers, GetPeersStatus}
 import scorex.core.network._
+import scorex.core.network.dns.DnsClientRef
+import scorex.core.network.dns.model.DnsClientInput
 import scorex.core.network.message.{PeersSpec, _}
-import scorex.core.network.peer.{LocalAddressPeerFeature, PeerManagerRef, LocalAddressPeerFeatureSerializer, PeersStatus, SessionIdPeerFeature}
+import scorex.core.network.peer.{LocalAddressPeerFeature, LocalAddressPeerFeatureSerializer, PeerManagerRef, PeersStatus, SessionIdPeerFeature}
 import scorex.core.settings.ScorexSettings
 import scorex.core.utils.LocalTimeProvider
 
@@ -322,6 +324,9 @@ class NetworkControllerSpec extends NetworkTests {
     val messageSpecs = Seq(GetPeersSpec, peersSpec)
     val scorexContext = ScorexContext(messageSpecs, Seq.empty, upnp, timeProvider, externalAddr)
 
+    val dnsClientInput = new DnsClientInput(Seq())
+    val dnsClient = DnsClientRef(dnsClientInput)
+
     val peerManagerRef = PeerManagerRef(settings, scorexContext)
 
     val networkControllerRef: ActorRef = NetworkControllerRef(
@@ -329,7 +334,7 @@ class NetworkControllerSpec extends NetworkTests {
       peerManagerRef, scorexContext, tcpManagerProbe.testActor)
 
     val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer",
-      networkControllerRef, peerManagerRef, settings.network, featureSerializers)
+      networkControllerRef, peerManagerRef, dnsClient, settings.network, featureSerializers)
 
 
     tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))


### PR DESCRIPTION
- Create a new actor responsible for DNS seeder lookups (DnsClient) and the strategies it will be collecting IP addresses with:
  - it will receive a GetDnsSeed with a strategy and return the IP addresses based on that strategy;
  - the strategies can be
    - get as many IP addresses as possible;
    - get the minimum number of IP addresses (just return the collection of IPs returned by the first DNS seeder);
    - get at least X number of IP addresses;
  - add a new network configuration called DnsSeeders;
  - unit tests.

- Create PeerManager and DnsClient interaction: 
  - when the PeerManager removes the last peer from the internal peer database, it sends an EmptyPeerDatabase message to the NetworkController that starts the flow asking the PeerSynchronizer to discover a new peer;
  - integration tests.