### PR TITLE
SDK-62: exclude unconfirmedConnections and already active connections

### DIFF
--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -224,7 +224,12 @@ class NetworkController(settings: NetworkSettings,
         log.debug(s"Looking for a new random connection")
         val randomPeerF = peerManagerRef ? RandomPeerExcluding(connections.values.flatMap(_.peerInfo).toSeq)
         randomPeerF.mapTo[Option[PeerInfo]].foreach { peerInfoOpt =>
-          peerInfoOpt.foreach(peerInfo => self ! ConnectTo(peerInfo))
+          peerInfoOpt.foreach { peerInfo =>
+            getPeerAddress(peerInfo).foreach { remote =>
+              if (connectionForPeerAddress(remote).isEmpty && !unconfirmedConnections.contains(remote))
+                self ! ConnectTo(peerInfo)
+            }
+          }
         }
       }
     }

--- a/src/main/scala/scorex/core/network/peer/PeerManager.scala
+++ b/src/main/scala/scorex/core/network/peer/PeerManager.scala
@@ -155,7 +155,7 @@ object PeerManager {
                           blacklistedPeers: Seq[InetAddress],
                           sc: ScorexContext): Option[PeerInfo] = {
         val candidates = knownPeers.values.filterNot { p =>
-          excludedPeers.contains(p.peerSpec.address) &&
+          excludedPeers.contains(p.peerSpec.address) ||
             blacklistedPeers.exists(addr => p.peerSpec.address.map(_.getAddress).contains(addr))
         }.toSeq
         if (candidates.nonEmpty) Some(candidates(Random.nextInt(candidates.size)))

--- a/src/main/scala/scorex/core/network/peer/PeerManager.scala
+++ b/src/main/scala/scorex/core/network/peer/PeerManager.scala
@@ -149,13 +149,13 @@ object PeerManager {
                           sc: ScorexContext): Map[InetSocketAddress, PeerInfo] = knownPeers
     }
 
-    case class RandomPeerExcluding(excludedPeers: Seq[PeerInfo]) extends GetPeers[Option[PeerInfo]] {
+    case class RandomPeerExcluding(excludedPeers: Seq[Option[InetSocketAddress]]) extends GetPeers[Option[PeerInfo]] {
 
       override def choose(knownPeers: Map[InetSocketAddress, PeerInfo],
                           blacklistedPeers: Seq[InetAddress],
                           sc: ScorexContext): Option[PeerInfo] = {
         val candidates = knownPeers.values.filterNot { p =>
-          excludedPeers.exists(_.peerSpec.address == p.peerSpec.address) &&
+          excludedPeers.contains(p.peerSpec.address) &&
             blacklistedPeers.exists(addr => p.peerSpec.address.map(_.getAddress).contains(addr))
         }.toSeq
         if (candidates.nonEmpty) Some(candidates(Random.nextInt(candidates.size)))

--- a/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
@@ -1,6 +1,4 @@
-package scorex.network
-
-import java.net.{InetAddress, InetSocketAddress}
+package scorex.core.network
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.io.Tcp
@@ -11,15 +9,19 @@ import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.TryValues._
 import org.scalatest.matchers.should.Matchers
-import scorex.core.app.{Version, ScorexContext}
+import scorex.core.app.{ScorexContext, Version}
+import scorex.core.network.NetworkController.ReceivableMessages.Internal.ConnectionToPeer
 import scorex.core.network.NetworkController.ReceivableMessages.{GetConnectedPeers, GetPeersStatus}
-import scorex.core.network._
-import scorex.core.network.message.{PeersSpec, _}
-import scorex.core.network.peer.{LocalAddressPeerFeature, PeerManagerRef, LocalAddressPeerFeatureSerializer, PeersStatus, SessionIdPeerFeature}
+import scorex.core.network.message._
+import scorex.core.network.peer.PeerManager.ReceivableMessages.AddOrUpdatePeer
+import scorex.core.network.peer._
 import scorex.core.settings.ScorexSettings
 import scorex.core.utils.LocalTimeProvider
+import scorex.network.NetworkTests
 
+import java.net.{InetAddress, InetSocketAddress}
 import scala.concurrent.ExecutionContext
+import scala.language.postfixOps
 
 class NetworkControllerSpec extends NetworkTests {
 
@@ -31,7 +33,7 @@ class NetworkControllerSpec extends NetworkTests {
     implicit val system = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
-    val networkControllerRef: ActorRef = createNetworkController(settings, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe)
     val testPeer = new TestPeer(settings, networkControllerRef, tcpManagerProbe)
 
     val peerAddr = new InetSocketAddress("127.0.0.1", 5678)
@@ -50,7 +52,7 @@ class NetworkControllerSpec extends NetworkTests {
     implicit val system = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
-    val networkControllerRef: ActorRef = createNetworkController(settings, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe)
     val testPeer = new TestPeer(settings, networkControllerRef, tcpManagerProbe)
 
     val nodeAddr = new InetSocketAddress("127.0.0.1", settings.network.bindAddress.getPort)
@@ -68,7 +70,7 @@ class NetworkControllerSpec extends NetworkTests {
     implicit val system = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
-    val networkControllerRef: ActorRef = createNetworkController(settings, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe)
     val testPeer = new TestPeer(settings, networkControllerRef, tcpManagerProbe)
 
     val nodeAddr = new InetSocketAddress("127.0.0.1", settings.network.bindAddress.getPort)
@@ -90,7 +92,7 @@ class NetworkControllerSpec extends NetworkTests {
 
     val bindAddress = new InetSocketAddress("88.77.66.55", 12345)
     val settings2 = settings.copy(network = settings.network.copy(bindAddress = bindAddress))
-    val networkControllerRef: ActorRef = createNetworkController(settings2, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe)
     val testPeer = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
 
     testPeer.connect(new InetSocketAddress("88.77.66.55", 5678), bindAddress)
@@ -111,7 +113,7 @@ class NetworkControllerSpec extends NetworkTests {
 
     val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
     val settings2 = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
-    val networkControllerRef: ActorRef = createNetworkController(settings2, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe)
     val testPeer1 = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
     val peer1Addr = new InetSocketAddress("88.77.66.55", 5678)
     testPeer1.connect(peer1Addr, nodeAddr)
@@ -139,7 +141,7 @@ class NetworkControllerSpec extends NetworkTests {
 
     val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
     val settings2 = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
-    val networkControllerRef: ActorRef = createNetworkController(settings2, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe)
 
     val testPeer1 = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
     val peer1DecalredAddr = new InetSocketAddress("88.77.66.55", 5678)
@@ -170,7 +172,7 @@ class NetworkControllerSpec extends NetworkTests {
 
     val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
     val settings2 = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
-    val networkControllerRef: ActorRef = createNetworkController(settings2, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe)
 
     val testPeer1 = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
     val peer1DecalredAddr = new InetSocketAddress("88.77.66.55", 5678)
@@ -206,7 +208,7 @@ class NetworkControllerSpec extends NetworkTests {
     ) { _ => None }
 
     val nodeAddr = new InetSocketAddress(gatewayAddr, settings.network.bindAddress.getPort)
-    val networkControllerRef: ActorRef = createNetworkController(settings, tcpManagerProbe, Some(upnp))
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe, Some(upnp))
 
     val testPeer1 = new TestPeer(settings, networkControllerRef, tcpManagerProbe)
     val peer1DecalredAddr = new InetSocketAddress("88.77.66.55", 5678)
@@ -234,7 +236,7 @@ class NetworkControllerSpec extends NetworkTests {
       InetAddress.getByName("192.169.1.11")
     ) { _ => Some(knownPeerLocalAddress) }
 
-    val networkControllerRef: ActorRef = createNetworkController(settings2, tcpManagerProbe, Some(upnp))
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe, Some(upnp))
 
     import scala.concurrent.duration._
     val connectAddr = tcpManagerProbe.expectMsgPF(10.seconds) {
@@ -252,7 +254,7 @@ class NetworkControllerSpec extends NetworkTests {
     val tcpManagerProbe = TestProbe()
 
     val nodeAddr = new InetSocketAddress("127.0.0.1", settings.network.bindAddress.getPort)
-    val networkControllerRef: ActorRef = createNetworkController(settings, tcpManagerProbe, None)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe, None)
     val testPeer = new TestPeer(settings, networkControllerRef, tcpManagerProbe)
 
     val peerLocalAddress = new InetSocketAddress("192.168.1.2", settings.network.bindAddress.getPort)
@@ -278,7 +280,7 @@ class NetworkControllerSpec extends NetworkTests {
 
     val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
     val settings2 = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
-    val networkControllerRef: ActorRef = createNetworkController(settings2, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe)
 
     val testPeer = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
     val peerAddr = new InetSocketAddress("88.77.66.55", 5678)
@@ -302,6 +304,109 @@ class NetworkControllerSpec extends NetworkTests {
     p.send(networkControllerRef, GetPeersStatus)
     val status = p.expectMsgClass(classOf[PeersStatus])
     status.lastIncomingMessage shouldBe ls
+
+    system.terminate()
+  }
+
+  it should "skip connection attempt if the only connection in PeerManager is marked as unconfirmed" in {
+    implicit val system: ActorSystem = ActorSystem()
+    val tcpManagerProbe = TestProbe()
+
+    val (networkControllerRef, peerManager) = createNetworkController(settings, tcpManagerProbe, None)
+
+    val peerAddressOne = new InetSocketAddress("88.77.66.55", 12345)
+    val peerInfoOne = getPeerInfo(peerAddressOne)
+
+    val activeConnections = Map.empty[InetSocketAddress, ConnectedPeer]
+    var unconfirmedConnections = Set.empty[InetSocketAddress]
+
+    unconfirmedConnections += peerAddressOne
+
+    peerManager ! AddOrUpdatePeer(peerInfoOne)
+
+    networkControllerRef ! ConnectionToPeer(activeConnections, unconfirmedConnections)
+
+    tcpManagerProbe.expectNoMessage()
+
+    system.terminate()
+  }
+
+  it should "select the only candidate existing in the PeerManager since there are neither active or unconfirmed connections" in {
+    implicit val system: ActorSystem = ActorSystem()
+    val tcpManagerProbe = TestProbe()
+
+    val (networkControllerRef, peerManager) = createNetworkController(settings, tcpManagerProbe, None)
+
+    val peerAddressOne = new InetSocketAddress("88.77.66.55", 12345)
+    val peerInfoOne = getPeerInfo(peerAddressOne)
+
+    val activeConnections = Map.empty[InetSocketAddress, ConnectedPeer]
+    val unconfirmedConnections = Set.empty[InetSocketAddress]
+
+    peerManager ! AddOrUpdatePeer(peerInfoOne)
+
+    networkControllerRef ! ConnectionToPeer(activeConnections, unconfirmedConnections)
+
+    tcpManagerProbe.expectMsgClass(classOf[Connect])
+
+    system.terminate()
+  }
+
+  it should "skip the peer connection attempt since the only peer in the PeerManager is already connected" in {
+    implicit val system: ActorSystem = ActorSystem()
+    val tcpManagerProbe = TestProbe()
+
+    val (networkControllerRef, peerManagerRef) = createNetworkController(settings, tcpManagerProbe, None)
+
+    val peerAddressOne = new InetSocketAddress("88.77.66.55", 12345)
+    val peerInfoOne = getPeerInfo(peerAddressOne)
+
+    var activeConnections = Map.empty[InetSocketAddress, ConnectedPeer]
+    val unconfirmedConnections = Set.empty[InetSocketAddress]
+
+    activeConnections += peerAddressOne -> ConnectedPeer(
+      ConnectionId(peerAddressOne, peerAddressOne, Incoming),
+      networkControllerRef,
+      1,
+      Some(peerInfoOne)
+    )
+
+    peerManagerRef ! AddOrUpdatePeer(peerInfoOne)
+
+    networkControllerRef ! ConnectionToPeer(activeConnections, unconfirmedConnections)
+
+    tcpManagerProbe.expectNoMessage()
+
+    system.terminate()
+  }
+
+  it should "connect to the second peer since is not an active or unconfirmed connection" in {
+    implicit val system: ActorSystem = ActorSystem()
+    val tcpManagerProbe = TestProbe()
+
+    val (networkControllerRef, peerManagerRef) = createNetworkController(settings, tcpManagerProbe, None)
+
+    val peerAddressOne = new InetSocketAddress("88.77.66.55", 12345)
+    val peerInfoOne = getPeerInfo(peerAddressOne)
+    val peerAddressTwo = new InetSocketAddress("55.66.77.88", 11223)
+    val peerInfoTwo = getPeerInfo(peerAddressTwo)
+
+    var activeConnections = Map.empty[InetSocketAddress, ConnectedPeer]
+    val unconfirmedConnections = Set.empty[InetSocketAddress]
+
+    activeConnections += peerAddressOne -> ConnectedPeer(
+      ConnectionId(peerAddressOne, peerAddressOne, Incoming),
+      networkControllerRef,
+      1,
+      Some(peerInfoOne)
+    )
+
+    peerManagerRef ! AddOrUpdatePeer(peerInfoOne)
+    peerManagerRef ! AddOrUpdatePeer(peerInfoTwo)
+
+    networkControllerRef ! ConnectionToPeer(activeConnections, unconfirmedConnections)
+
+    tcpManagerProbe.expectMsgClass(classOf[Connect])
 
     system.terminate()
   }
@@ -335,7 +440,7 @@ class NetworkControllerSpec extends NetworkTests {
     tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))
 
     tcpManagerProbe.send(networkControllerRef, Bound(settings.network.bindAddress))
-    networkControllerRef
+    (networkControllerRef, peerManagerRef)
   }
 }
 

--- a/src/test/scala/scorex/network/NetworkTests.scala
+++ b/src/test/scala/scorex/network/NetworkTests.scala
@@ -1,14 +1,14 @@
 package scorex.network
 
 import java.net.InetSocketAddress
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scorex.core.app.Version
-import scorex.core.network.PeerSpec
+import scorex.core.network.{PeerFeature, PeerSpec}
 import scorex.core.network.peer.PeerInfo
 import scorex.core.settings.ScorexSettings
 import scorex.core.utils.{NetworkTimeProvider, TimeProvider}
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class NetworkTests extends AnyFlatSpec with Matchers {
@@ -18,8 +18,8 @@ class NetworkTests extends AnyFlatSpec with Matchers {
 
   protected def currentTime(): TimeProvider.Time = timeProvider.time()
 
-  protected def getPeerInfo(address: InetSocketAddress, nameOpt: Option[String] = None): PeerInfo = {
-    val data = PeerSpec("full node", Version.last, nameOpt.getOrElse(address.toString), Some(address), Seq())
+  protected def getPeerInfo(address: InetSocketAddress, nameOpt: Option[String] = None, featureSeq: Seq[PeerFeature] = Seq()): PeerInfo = {
+    val data = PeerSpec("full node", Version.last, nameOpt.getOrElse(address.toString), Some(address), featureSeq)
     PeerInfo(data, currentTime(), None)
   }
 


### PR DESCRIPTION
This fixes the node trying to connect to already established connections