### PR TITLE
Sdk 237 limit peers database

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -173,6 +173,9 @@ scorex {
     # Maximum number of PeerSpec objects in one Peers message
     maxPeerSpecObjects = 64
 
+    # Maximum number of PeerSpec objects in one Peers message
+    storedPeersLimit = 1024
+
     # Default ban duration, unless permanent penalty is applied
     temporalBanDuration = 60m
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -173,7 +173,7 @@ scorex {
     # Maximum number of PeerSpec objects in one Peers message
     maxPeerSpecObjects = 64
 
-    # Maximum number of PeerSpec objects in one Peers message
+    # Maximum number of PeerSpec objects stored in the in-memory database
     storedPeersLimit = 1024
 
     # Default ban duration, unless permanent penalty is applied

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, RegisterMessageSpecs, SendToNetwork}
 import scorex.core.network.message.{GetPeersSpec, Message, MessageSpec, PeersSpec}
 import scorex.core.network.peer.{PeerInfo, PenaltyType}
-import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddPeerIfEmpty, SeenPeers}
+import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddPeersIfEmpty, SeenPeers}
 import scorex.core.settings.NetworkSettings
 import scorex.util.ScorexLogging
 import shapeless.syntax.typeable._
@@ -62,7 +62,7 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
     * @param peers sequence of peer specs describing a remote peers details
     */
   private def addNewPeers(peers: Seq[PeerSpec]): Unit = {
-    peers.foreach(peerSpec => peerManager ! AddPeerIfEmpty(peerSpec))
+    peerManager ! AddPeersIfEmpty(peers)
   }
 
   /**

--- a/src/main/scala/scorex/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/scorex/core/network/peer/InMemoryPeerDatabase.scala
@@ -35,7 +35,7 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
     }
   }
 
-  /*
+  /**
    * Adds a peer to the in-memory database ignoring the configurable limit.
    * Used for high-priority peers, like peers from config file or connected peers
    */

--- a/src/main/scala/scorex/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/scorex/core/network/peer/InMemoryPeerDatabase.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimeProvider)
   extends PeerDatabase with ScorexLogging {
 
-  private var peers = Map.empty[InetSocketAddress, PeerInfo]
+  private var peers = Map.empty[InetSocketAddress, (PeerInfo, TimeProvider.Time)]
 
   /**
     * banned peer ip -> ban expiration timestamp
@@ -26,15 +26,43 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
     */
   private var penaltyBook = Map.empty[InetAddress, (Int, Long)]
 
-  override def get(peer: InetSocketAddress): Option[PeerInfo] = peers.get(peer)
+  override def get(peer: InetSocketAddress): Option[PeerInfo] = peers.get(peer).map(_._1)
+
+  private def addPeer(peerInfo: PeerInfo): Unit = {
+    peerInfo.peerSpec.address.foreach { address =>
+      log.debug(s"Updating peer info for $address")
+      peers += address -> (peerInfo, timeProvider.time())
+    }
+  }
 
   override def addOrUpdateKnownPeer(peerInfo: PeerInfo): Unit = {
     if (!peerInfo.peerSpec.declaredAddress.exists(x => isBlacklisted(x.getAddress))) {
-      peerInfo.peerSpec.address.foreach { address =>
-        log.debug(s"Updating peer info for $address")
-        peers += address -> peerInfo
-      }
+      addPeer(peerInfo)
     }
+  }
+
+  override def addOrUpdateKnownPeers(peersInfo: Seq[PeerInfo]): Unit = {
+    val validPeers = peersInfo.filterNot {_.peerSpec.declaredAddress.exists(x => isBlacklisted(x.getAddress))}
+    if (peers.size + validPeers.size > settings.storedPeersLimit) {
+      addOrReplaceOldPeers(validPeers)
+    }
+    else
+      validPeers.foreach(addPeer)
+  }
+
+  private def addOrReplaceOldPeers(validPeers: Seq[PeerInfo]): Unit = {
+    val needToRemove = peers.size + validPeers.size - settings.storedPeersLimit
+    //it can be that all peers are connected, so we won't make enough place
+    val canRemove = peers.toSeq
+      .filter { p => p._2._1.connectionType.isEmpty || p._2._1.lastHandshake == 0 }
+      .sortBy { p => p._2._2 }(Ordering.Long)
+      .take(needToRemove)
+    canRemove
+      .foreach(p => remove(p._1))
+
+    validPeers
+      .take(validPeers.size - (needToRemove - canRemove.size))
+      .foreach(addPeer)
   }
 
   override def addToBlacklist(socketAddress: InetSocketAddress,
@@ -57,7 +85,7 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
     peers -= address
   }
 
-  override def knownPeers: Map[InetSocketAddress, PeerInfo] = peers
+  override def knownPeers: Map[InetSocketAddress, PeerInfo] = peers.transform { (_, info_time) => info_time._1 }
 
   override def blacklistedPeers: Seq[InetAddress] = blacklist
     .map { case (address, bannedTill) =>
@@ -76,6 +104,7 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
 
   /**
     * Registers a new penalty in the penalty book.
+    *
     * @return - `true` if penalty threshold is reached, `false` otherwise.
     */
   def penalize(socketAddress: InetSocketAddress, penaltyType: PenaltyType): Boolean =

--- a/src/main/scala/scorex/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/scorex/core/network/peer/InMemoryPeerDatabase.scala
@@ -35,6 +35,10 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
     }
   }
 
+  /*
+   * Adds a peer to the in-memory database ignoring the configurable limit.
+   * Used for high-priority peers, like peers from config file or connected peers
+   */
   override def addOrUpdateKnownPeer(peerInfo: PeerInfo): Unit = {
     if (!peerInfo.peerSpec.declaredAddress.exists(x => isBlacklisted(x.getAddress))) {
       addPeer(peerInfo)

--- a/src/main/scala/scorex/core/network/peer/PeerDatabase.scala
+++ b/src/main/scala/scorex/core/network/peer/PeerDatabase.scala
@@ -10,9 +10,12 @@ trait PeerDatabase {
 
   /**
     * Add peer to the database, or update it
+    *
     * @param peerInfo - peer record
     */
   def addOrUpdateKnownPeer(peerInfo: PeerInfo): Unit
+
+  def addOrUpdateKnownPeers(peersInfo: Seq[PeerInfo]): Unit
 
   def knownPeers: Map[InetSocketAddress, PeerInfo]
 
@@ -25,5 +28,4 @@ trait PeerDatabase {
   def isBlacklisted(address: InetAddress): Boolean
 
   def remove(address: InetSocketAddress): Unit
-
 }

--- a/src/main/scala/scorex/core/network/peer/PeerManager.scala
+++ b/src/main/scala/scorex/core/network/peer/PeerManager.scala
@@ -54,13 +54,16 @@ class PeerManager(settings: ScorexSettings, scorexContext: ScorexContext) extend
         sender() ! Blacklisted(peer)
       }
 
-    case AddPeerIfEmpty(peerSpec) =>
-      // We have received peer data from other peers. It might be modified and should not affect existing data if any
-      if (peerSpec.address.forall(a => peerDatabase.get(a).isEmpty) && !isSelf(peerSpec)) {
-        val peerInfo: PeerInfo = PeerInfo(peerSpec, 0, None)
-        log.info(s"New discovered peer: $peerInfo")
-        peerDatabase.addOrUpdateKnownPeer(peerInfo)
-      }
+    case AddPeersIfEmpty(peersSpec) =>
+      // We have received peers data from other peers. It might be modified and should not affect existing data if any
+      val filteredPeers = peersSpec
+        .collect {
+          case peerSpec if peerSpec.address.forall(a => peerDatabase.get(a).isEmpty) && !isSelf(peerSpec) =>
+            val peerInfo: PeerInfo = PeerInfo(peerSpec, 0L, None)
+            log.info(s"New discovered peer: $peerInfo")
+            peerInfo
+        }
+      peerDatabase.addOrUpdateKnownPeers(filteredPeers)
 
     case RemovePeer(address) =>
       log.info(s"$address removed from peers database")
@@ -110,7 +113,7 @@ object PeerManager {
     // peerListOperations messages
     case class AddOrUpdatePeer(data: PeerInfo)
 
-    case class AddPeerIfEmpty(data: PeerSpec)
+    case class AddPeersIfEmpty(data: Seq[PeerSpec])
 
     case class RemovePeer(address: InetSocketAddress)
 

--- a/src/main/scala/scorex/core/settings/Settings.scala
+++ b/src/main/scala/scorex/core/settings/Settings.scala
@@ -48,6 +48,7 @@ case class NetworkSettings(nodeName: String,
                            magicBytes: Array[Byte],
                            getPeersInterval: FiniteDuration,
                            maxPeerSpecObjects: Int,
+                           storedPeersLimit: Int,
                            temporalBanDuration: FiniteDuration,
                            penaltySafeInterval: FiniteDuration,
                            penaltyScoreThreshold: Int)


### PR DESCRIPTION
~adding a limit for N of incoming peers~ - this is done during deserialization

adding a map size limit

adding logic for replacing old with new peers