### PR TITLE
SDK-301: add latency based on message code

### DIFF
--- a/src/main/scala/sparkz/core/settings/Settings.scala
+++ b/src/main/scala/sparkz/core/settings/Settings.scala
@@ -54,7 +54,18 @@ case class NetworkSettings(nodeName: String,
                            storedPeersLimit: Int,
                            temporalBanDuration: FiniteDuration,
                            penaltySafeInterval: FiniteDuration,
-                           penaltyScoreThreshold: Int)
+                           penaltyScoreThreshold: Int,
+                           messageDelays: MessageDelays
+                          )
+
+case class MessageDelays(
+                          GetPeersSpec: Long = 0,
+                          PeerSpec: Long = 0,
+                          Transaction: Long = 0,
+                          Block: Long = 0,
+                          RequestModifierSpec: Long = 0,
+                          ModifiersSpec: Long = 0
+                        )
 
 case class SparkzSettings(dataDir: File,
                           logDir: File,

--- a/src/main/scala/sparkz/core/utils/TpsUtils.scala
+++ b/src/main/scala/sparkz/core/utils/TpsUtils.scala
@@ -1,0 +1,39 @@
+package sparkz.core.utils
+
+import sparkz.core.network.message._
+import sparkz.core.settings.MessageDelays
+import sparkz.core.transaction.Transaction
+
+import scala.language.existentials
+import scala.util.Success
+
+object TpsUtils {
+  def addDelay(msg: Message[_], delaySettings: MessageDelays): Long = {
+    msg.spec.messageCode match {
+      case GetPeersSpec.messageCode => delaySettings.GetPeersSpec
+      case PeersSpec.messageCode => delaySettings.PeerSpec
+      case InvSpec.MessageCode => msg match {
+        case Message(spec, Left(msgBytes), _) =>
+          spec.parseBytesTry(msgBytes) match {
+            case Success(content) =>
+              handleInvSpecContent(delaySettings, spec, content)
+            case _ => 0
+          }
+        case Message(spec, Right(content), _) =>
+          handleInvSpecContent(delaySettings, spec, content)
+        case _ => 0
+      }
+      case RequestModifierSpec.MessageCode => delaySettings.RequestModifierSpec
+      case ModifiersSpec.MessageCode => delaySettings.ModifiersSpec
+      case _ => 0
+    }
+  }
+
+  private def handleInvSpecContent(delaySettings: MessageDelays, spec: MessageSpec[_], content: Any): Long = {
+    val parsedMsg = (spec, content, None)
+    parsedMsg match {
+      case (_: InvSpec, data: InvData, _) if data.typeId == Transaction.ModifierTypeId => delaySettings.Transaction
+      case _ => delaySettings.Block
+    }
+  }
+}

--- a/src/test/scala/sparkz/core/utils/TpsUtilsTest.scala
+++ b/src/test/scala/sparkz/core/utils/TpsUtilsTest.scala
@@ -1,0 +1,93 @@
+package sparkz.core.utils
+
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.propspec.AnyPropSpec
+import scorex.util.serialization.{Reader, VLQByteBufferWriter, Writer}
+import scorex.util.{ByteArrayBuilder, ModifierId}
+import sparkz.core.ModifierTypeId
+import sparkz.core.network.message.Message.MessageCode
+import sparkz.core.network.message._
+import sparkz.core.settings.MessageDelays
+import sparkz.core.transaction.Transaction
+
+class TpsUtilsTest extends AnyPropSpec {
+  private val defaultModifierDelay = 0
+  private val getPeersSpecDelay = 1
+  private val peerSpecDelay = 2
+  private val transactionDelay = 3
+  private val blockDelay = 4
+  private val requestModifierSpecDelay = 5
+  private val modifiersSpecDelay = 6
+
+  private val delaySettings = MessageDelays(
+    getPeersSpecDelay,
+    peerSpecDelay,
+    transactionDelay,
+    blockDelay,
+    requestModifierSpecDelay,
+    modifiersSpecDelay
+  )
+
+  property("Returns correct delay for InvData Transaction with content") {
+    val invSpec = new InvSpec(5)
+    val content = Right(InvData(Transaction.ModifierTypeId, Seq(ModifierId @@ "2e5b8fee0256805f0c630314a4ad19d0277ee7947ced935f774efeed811f27e1")))
+    val message = Message(invSpec, content, None)
+    val result = TpsUtils.addDelay(message, delaySettings)
+    result shouldBe transactionDelay
+  }
+
+  property("Returns correct delay for InvData Transaction with byteArray") {
+    val invSpec = new InvSpec(5)
+    val invData = InvData(Transaction.ModifierTypeId, Seq(ModifierId @@ "2e5b8fee0256805f0c630314a4ad19d0277ee7947ced935f774efeed811f27e1"))
+    val writer = new VLQByteBufferWriter(new ByteArrayBuilder())
+    invSpec.serialize(invData, writer)
+    val content = Left(writer.result().toBytes)
+    val message = Message(invSpec, content, None)
+    val result = TpsUtils.addDelay(message, delaySettings)
+    result shouldBe transactionDelay
+  }
+
+  property("Returns correct delay for ModifiersSpec") {
+    val modSpec = new ModifiersSpec(5)
+    val content = Right(ModifiersData(ModifierTypeId @@ 100.toByte, Map()))
+    val message = Message(modSpec, content, None)
+    val result = TpsUtils.addDelay(message, delaySettings)
+    result shouldBe modifiersSpecDelay
+  }
+
+
+  property("Returns correct delay for GetPeersSpec") {
+    val message = Message(GetPeersSpec, Left(Array(100.toByte)), None)
+    val result = TpsUtils.addDelay(message, delaySettings)
+    result shouldBe getPeersSpecDelay
+  }
+
+  property("Returns correct delay for RequestModifierSpec") {
+    val requestModifierSpec = new RequestModifierSpec(5)
+    val message = Message(requestModifierSpec, Left(Array(100.toByte)), None)
+    val result = TpsUtils.addDelay(message, delaySettings)
+    result shouldBe requestModifierSpecDelay
+  }
+
+  property("Returns default delay for Message spec not in the list") {
+    val requestModifierSpec = new FakeSpec
+    val message = Message(requestModifierSpec, Left(Array(100.toByte)), None)
+    val result = TpsUtils.addDelay(message, delaySettings)
+    result shouldBe defaultModifierDelay
+  }
+}
+class FakeData
+class FakeSpec extends MessageSpecV1[FakeData] {
+  /**
+    * Code which identifies what message type is contained in the payload
+    */
+  override val messageCode: MessageCode = 123.toByte
+  /**
+    * Name of this message type. For debug purposes only.
+    */
+  override val messageName: String = "fakeMessage"
+
+  override def serialize(obj: FakeData, w: Writer): Unit = ???
+
+  override def parse(r: Reader): FakeData = ???
+}


### PR DESCRIPTION
Add delays for specific message types; the delay is configurable from the config file using the `messageDelays` field