### PR TITLE
Scala cross version build CI/CD changes

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -5,10 +5,10 @@ retval=0
 
 if [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?(-SNAPSHOT){1}[0-9]*$ ]]; then
   echo "" && echo "=== Publishing development release on Sonatype Nexus repository. Timestamp is: $(date '+%a %b %d %H:%M:%S %Z %Y') ===" && echo ""
-  sbt -ivy ./.ivy2 -sbt-dir ./.sbt publish
+  sbt -ivy ./.ivy2 -sbt-dir ./.sbt +publish
 elif [[ "${TRAVIS_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?$ ]]; then
   echo "" && echo "=== Publishing production release on Maven repository. Timestamp is: $(date '+%Y-%m-%d %H:%M') ===" && echo ""
-  sbt -ivy ./.ivy2 -sbt-dir ./.sbt publishSigned sonatypeBundleRelease
+  sbt -ivy ./.ivy2 -sbt-dir ./.sbt +publishSigned sonatypeBundleRelease
 else
   echo "" && echo "=== Not going to publish!!! Release tag = ${TRAVIS_TAG} did not match either DEV or PROD format requirements ===" && echo ""
 fi

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -61,7 +61,7 @@ if [ -n "${TRAVIS_TAG}" ]; then
     if ( git branch -r --contains "${TRAVIS_TAG}" | grep -xqE ". origin\/${PROD_RELEASE_BRANCH}$" ); then
       # Checking if package version matches PROD release version
       if ! [[ "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?$ ]]; then
-        echo "Aborting, package version is in the wrong format."
+        echo "Aborting, package version is in the wrong format for production release."
         exit 1
       fi
 
@@ -81,7 +81,7 @@ if [ -n "${TRAVIS_TAG}" ]; then
     else
       # Checking if package version matches DEV release version
       if ! [[ "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?(-SNAPSHOT){1}$ ]]; then
-        echo "Aborting, package version is in the wrong format."
+        echo "Aborting, package version is in the wrong format for development release."
         exit 1
       fi
 


### PR DESCRIPTION
This PR adds changes to CI/CD code needed to provide publishing for Scala cross version builds. 

- PROD release published on Maven Central: https://repo.maven.apache.org/maven2/io/horizen/ **0.0.2-SNAPSHOT**
- DEV release published on Sonatype: https://oss.sonatype.org/content/repositories/snapshots/io/horizen/ **0.0.1-RC4**