### PR TITLE
Sdk 484 - Introduce peer storages persistence

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -103,6 +103,16 @@ sparkz {
     connectionTimeout = 1s
 
     ############################
+    # Peers' storages settings #
+    ############################
+
+    # Interval to backup peers' storages
+    storageBackupInterval = 15m
+
+    # Delay to start peers' backup
+    storageBackupDelay = 5m
+
+    ############################
     # Delivery settings limits #
     ############################
 

--- a/src/main/scala/sparkz/core/app/Application.scala
+++ b/src/main/scala/sparkz/core/app/Application.scala
@@ -1,20 +1,28 @@
 package sparkz.core.app
 
-import java.net.InetSocketAddress
-
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
+import scorex.util.ScorexLogging
 import sparkz.core.api.http.{ApiErrorHandler, ApiRejectionHandler, ApiRoute, CompositeHttpService}
 import sparkz.core.network._
 import sparkz.core.network.message._
-import sparkz.core.network.peer.PeerManagerRef
-import sparkz.core.settings.SparkzSettings
+import sparkz.core.network.peer.PeerBucketStorage.{BucketConfig, NewPeerBucketStorage, TriedPeerBucketStorage}
+import sparkz.core.network.peer.{BucketManager, InMemoryPeerDatabase, PeerManagerRef}
+import sparkz.core.settings.{NetworkSettings, SparkzSettings}
+import sparkz.core.storage.ScheduledActor.ScheduledActorConfig
+import sparkz.core.storage.ScheduledStorageFilePersister.ScheduledStorageFilePersisterConfig
+import sparkz.core.storage.ScheduledStoragePersister.ScheduledStoragePersisterConfig
+import sparkz.core.storage.StoragePersisterContainer.StoragePersisterContainerConfig
+import sparkz.core.storage.{ScheduledMapPersister, ScheduledPeerBucketPersister, ScheduledStoragePersister, StoragePersisterContainer}
 import sparkz.core.transaction.Transaction
 import sparkz.core.utils.NetworkTimeProvider
+import sparkz.core.utils.TimeProvider.Time
 import sparkz.core.{NodeViewHolder, PersistentNodeViewModifier}
-import scorex.util.ScorexLogging
 
+import java.net.{InetAddress, InetSocketAddress}
+import java.security.SecureRandom
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
 trait Application extends ScorexLogging {
@@ -32,9 +40,11 @@ trait Application extends ScorexLogging {
   val apiRoutes: Seq[ApiRoute]
 
   implicit def exceptionHandler: ExceptionHandler = ApiErrorHandler.exceptionHandler
+
   implicit def rejectionHandler: RejectionHandler = ApiRejectionHandler.rejectionHandler
 
-  protected implicit lazy val actorSystem: ActorSystem = ActorSystem(settings.network.agentName)
+  private val networkSettings: NetworkSettings = settings.network
+  protected implicit lazy val actorSystem: ActorSystem = ActorSystem(networkSettings.agentName)
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup("sparkz.executionContext")
 
   protected val features: Seq[PeerFeature]
@@ -42,12 +52,12 @@ trait Application extends ScorexLogging {
   private val featureSerializers: PeerFeature.Serializers = features.map(f => f.featureId -> f.serializer).toMap
 
   private lazy val basicSpecs = {
-    val invSpec = new InvSpec(settings.network.maxInvObjects)
-    val requestModifierSpec = new RequestModifierSpec(settings.network.maxInvObjects)
-    val modifiersSpec = new ModifiersSpec(settings.network.maxModifiersSpecMessageSize)
+    val invSpec = new InvSpec(networkSettings.maxInvObjects)
+    val requestModifierSpec = new RequestModifierSpec(networkSettings.maxInvObjects)
+    val modifiersSpec = new ModifiersSpec(networkSettings.maxModifiersSpecMessageSize)
     Seq(
       GetPeersSpec,
-      new PeersSpec(featureSerializers, settings.network.maxPeerSpecObjects),
+      new PeersSpec(featureSerializers, networkSettings.maxPeerSpecObjects),
       invSpec,
       requestModifierSpec,
       modifiersSpec
@@ -64,28 +74,78 @@ trait Application extends ScorexLogging {
 
   //an address to send to peers
   lazy val externalSocketAddress: Option[InetSocketAddress] = {
-    settings.network.declaredAddress
+    networkSettings.declaredAddress
   }
 
-  val sparkzContext = SparkzContext(
+  val sparkzContext: SparkzContext = SparkzContext(
     messageSpecs = basicSpecs ++ additionalMessageSpecs,
     features = features,
     timeProvider = timeProvider,
     externalNodeAddress = externalSocketAddress
   )
 
-  val peerManagerRef = PeerManagerRef(settings, sparkzContext)
+  private val nKey: Int = new SecureRandom().nextInt()
+  private val newBucketConfig: BucketConfig = BucketConfig(buckets = 1024, bucketPositions = 64, bucketSubgroups = 64)
+  private val triedBucketConfig: BucketConfig = BucketConfig(buckets = 256, bucketPositions = 64, bucketSubgroups = 8)
+
+  private def createPeerDatabaseDataStructures: (
+    NewPeerBucketStorage, TriedPeerBucketStorage, mutable.Map[InetAddress, Time], mutable.Map[InetAddress, (Int, Time)]
+    ) = {
+    val triedBucket: TriedPeerBucketStorage = TriedPeerBucketStorage(triedBucketConfig, nKey, timeProvider)
+    val newBucket: NewPeerBucketStorage = NewPeerBucketStorage(newBucketConfig, nKey, timeProvider)
+    val blacklist = mutable.Map.empty[InetAddress, Time]
+    val penaltyBook = mutable.Map.empty[InetAddress, (Int, Time)]
+
+    (newBucket, triedBucket, blacklist, penaltyBook)
+  }
+
+  private def createStoragePersisters(triedBucket: TriedPeerBucketStorage, newBucket: NewPeerBucketStorage): Seq[ScheduledStoragePersister[_]] = {
+    val scheduledStorageWriterConfig = ScheduledStoragePersisterConfig(
+      ScheduledActorConfig(networkSettings.storageBackupDelay, networkSettings.storageBackupInterval)
+    )
+    val blacklistWriterConfig = ScheduledStorageFilePersisterConfig(settings.dataDir, "BlacklistPeers.dat", scheduledStorageWriterConfig)
+    val blacklistPersister = new ScheduledMapPersister[InetAddress, Time](blacklist, blacklistWriterConfig)
+
+    val penaltyWriterConfig = ScheduledStorageFilePersisterConfig(settings.dataDir, "PenaltyBook.dat", scheduledStorageWriterConfig)
+    val penaltyBookPersister = new ScheduledMapPersister[InetAddress, (Int, Long)](penaltyBook, penaltyWriterConfig)
+
+    val triedWriterConfig = ScheduledStorageFilePersisterConfig(settings.dataDir, triedBucket.STORAGE_LABEL, scheduledStorageWriterConfig)
+    val triedBucketPersister = new ScheduledPeerBucketPersister(triedBucket, triedWriterConfig)
+
+    val newWriterConfig = ScheduledStorageFilePersisterConfig(settings.dataDir, newBucket.STORAGE_LABEL, scheduledStorageWriterConfig)
+    val newBucketPersister = new ScheduledPeerBucketPersister(newBucket, newWriterConfig)
+    Seq(blacklistPersister, penaltyBookPersister, triedBucketPersister, newBucketPersister)
+  }
+
+  private val (newBucket, triedBucket, blacklist, penaltyBook) = createPeerDatabaseDataStructures
+  val bucketManager: BucketManager = new BucketManager(newBucket, triedBucket)
+
+  private val peerDatabase = new InMemoryPeerDatabase(
+    networkSettings,
+    sparkzContext.timeProvider,
+    bucketManager,
+    blacklist,
+    penaltyBook
+  )
+
+  private val storagePersisterContainer = new StoragePersisterContainer(
+    createStoragePersisters(triedBucket, newBucket),
+    StoragePersisterContainerConfig(settings.dataDir)
+  )
+  storagePersisterContainer.restoreAllStorages()
+
+  val peerManagerRef: ActorRef = PeerManagerRef(settings, sparkzContext, peerDatabase)
 
   val networkControllerRef: ActorRef = NetworkControllerRef(
-    "networkController", settings.network, peerManagerRef, sparkzContext)
+    "networkController", networkSettings, peerManagerRef, sparkzContext)
 
   val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer",
-    networkControllerRef, peerManagerRef, settings.network, featureSerializers)
+    networkControllerRef, peerManagerRef, networkSettings, featureSerializers)
 
   lazy val combinedRoute: Route = CompositeHttpService(actorSystem, apiRoutes, settings.restApi, swaggerConfig).compositeRoute
 
   def run(): Unit = {
-    require(settings.network.agentName.length <= Application.ApplicationNameLimit)
+    require(networkSettings.agentName.length <= Application.ApplicationNameLimit)
 
     log.debug(s"Available processors: ${Runtime.getRuntime.availableProcessors}")
     log.debug(s"Max memory available: ${Runtime.getRuntime.maxMemory}")

--- a/src/main/scala/sparkz/core/network/ConnectedPeer.scala
+++ b/src/main/scala/sparkz/core/network/ConnectedPeer.scala
@@ -24,4 +24,12 @@ case class ConnectedPeer(connectionId: ConnectionId,
   }
 
   override def toString: String = s"ConnectedPeer($connectionId)"
+
+  def toSourcePeer: SourcePeer = SourcePeer(connectionId, lastMessage, peerInfo)
+}
+
+case class SourcePeer(connectionId: ConnectionId,
+                      lastMessage: Long,
+                      peerInfo: Option[PeerInfo]) {
+
 }

--- a/src/main/scala/sparkz/core/network/NetworkController.scala
+++ b/src/main/scala/sparkz/core/network/NetworkController.scala
@@ -276,7 +276,7 @@ class NetworkController(settings: NetworkSettings,
     val unconfirmedConnectionsAddressSeq = unconfirmedConnections.map(connection => PeerInfo.fromAddress(connection)).toSeq
     val mergedSeq = connectionsAddressSeq ++ unconfirmedConnectionsAddressSeq
     val peersAddresses = mergedSeq.map(getPeerAddress)
-    val randomPeerF = peerManagerRef ? RandomPeerExcluding(peersAddresses)
+    val randomPeerF = peerManagerRef ? RandomPeerForConnectionExcluding(peersAddresses)
     randomPeerF.mapTo[Option[PeerInfo]].foreach {
       case Some(peerInfo) => self ! ConnectTo(peerInfo)
       case None => log.warn("Could not find a peer to connect to, skipping this connectionToPeer round")

--- a/src/main/scala/sparkz/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/sparkz/core/network/PeerSynchronizer.scala
@@ -26,8 +26,8 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
   private val peersSpec = new PeersSpec(featureSerializers, settings.maxPeerSpecObjects)
 
   protected override val msgHandlers: PartialFunction[(MessageSpec[_], _, ConnectedPeer), Unit] = {
-    case (_: PeersSpec, peers: Seq[PeerSpec]@unchecked, _) if peers.cast[Seq[PeerSpec]].isDefined =>
-      addNewPeers(peers)
+    case (_: PeersSpec, peers: Seq[PeerSpec]@unchecked, sourcePeer: ConnectedPeer) if peers.cast[Seq[PeerSpec]].isDefined =>
+      addNewPeers(peers, sourcePeer)
 
     case (spec, _, remote) if spec.messageCode == GetPeersSpec.messageCode =>
       gossipPeers(remote)
@@ -61,8 +61,8 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
     *
     * @param peers sequence of peer specs describing a remote peers details
     */
-  private def addNewPeers(peers: Seq[PeerSpec]): Unit = {
-    peerManager ! AddPeersIfEmpty(peers)
+  private def addNewPeers(peers: Seq[PeerSpec], sourcePeer: ConnectedPeer): Unit = {
+    peerManager ! AddPeersIfEmpty(peers, sourcePeer)
   }
 
   /**

--- a/src/main/scala/sparkz/core/network/peer/BucketManager.scala
+++ b/src/main/scala/sparkz/core/network/peer/BucketManager.scala
@@ -1,0 +1,73 @@
+package sparkz.core.network.peer
+
+import sparkz.core.network.SourcePeer
+import sparkz.core.network.peer.BucketManager.Exception.PeerNotFoundException
+import sparkz.core.network.peer.BucketManager.PeerBucketValue
+import sparkz.core.network.peer.PeerBucketStorage._
+
+import java.net.InetSocketAddress
+import scala.util.Random
+
+class BucketManager(private val newBucket: NewPeerBucketStorage, private val triedBucket: TriedPeerBucketStorage) {
+  def addNewPeer(peerBucketValue: PeerBucketValue): Unit = {
+    newBucket.add(peerBucketValue)
+  }
+
+  def makeTried(address: InetSocketAddress): Unit = {
+    val peerToBeMovedInTried = newBucket
+      .getStoredPeerByAddress(address)
+      .getOrElse(
+        throw PeerNotFoundException(s"Cannot move peer $address to tried table because it doesn't exist in new")
+      )
+    newBucket.remove(address)
+
+    if (triedBucket.bucketPositionIsAlreadyTaken(peerToBeMovedInTried)) {
+      val (bucket, bucketPosition) = triedBucket.getPeerIndexes(peerToBeMovedInTried)
+      val peerToBeRemovedOption = triedBucket.getStoredPeerByIndexes(bucket, bucketPosition)
+      val peerToBeRemoved = peerToBeRemovedOption.getOrElse(throw new IllegalArgumentException())
+      val addressToBeRemoved = peerToBeRemoved.peerInfo.peerSpec.address.getOrElse(throw new IllegalArgumentException())
+      triedBucket.remove(addressToBeRemoved)
+
+      addNewPeer(peerToBeRemoved)
+    }
+
+    triedBucket.add(peerToBeMovedInTried)
+  }
+
+  def removePeer(address: InetSocketAddress): Unit = {
+    newBucket.remove(address)
+    triedBucket.remove(address)
+  }
+
+  def isEmpty: Boolean = triedBucket.isEmpty && newBucket.isEmpty
+
+  def getNewPeers: Map[InetSocketAddress, PeerInfo] = newBucket.getPeers
+
+  def getTriedPeers: Map[InetSocketAddress, PeerInfo] = triedBucket.getPeers
+
+  def getRandomPeers: Map[InetSocketAddress, PeerInfo] = {
+    val pickFromNewBucket = new Random().nextBoolean()
+
+    if ((pickFromNewBucket && newBucket.nonEmpty) || triedBucket.isEmpty)
+      newBucket.getPeers
+    else
+      triedBucket.getPeers
+  }
+
+  def getPeer(peerAddress: InetSocketAddress): Option[PeerBucketValue] = {
+    triedBucket.getStoredPeerByAddress(peerAddress) match {
+      case peer: Some[PeerBucketValue] => peer
+      case _ => newBucket.getStoredPeerByAddress(peerAddress)
+    }
+  }
+}
+
+object BucketManager {
+  case class BucketManagerConfig(newBucketConfig: BucketConfig, triedBucketConfig: BucketConfig, nKey: Int)
+
+  case class PeerBucketValue(peerInfo: PeerInfo, source: SourcePeer, isNew: Boolean)
+
+  case object Exception {
+    case class PeerNotFoundException(msg: String) extends Exception(msg)
+  }
+}

--- a/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
@@ -1,79 +1,56 @@
 package sparkz.core.network.peer
 
-import java.net.{InetAddress, InetSocketAddress}
+import scorex.util.ScorexLogging
+import sparkz.core.network.ConnectedPeer
+import sparkz.core.network.peer.BucketManager.PeerBucketValue
+import sparkz.core.network.peer.PenaltyType.DisconnectPenalty
 import sparkz.core.settings.NetworkSettings
 import sparkz.core.utils.TimeProvider
-import scorex.util.ScorexLogging
-import sparkz.core.network.peer.PenaltyType.DisconnectPenalty
 
+import java.net.{InetAddress, InetSocketAddress}
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 /**
   * In-memory peer database implementation supporting temporal blacklisting.
   */
-final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimeProvider)
+final class InMemoryPeerDatabase(
+                                  settings: NetworkSettings,
+                                  timeProvider: TimeProvider,
+                                  bucketManager: BucketManager,
+                                  blacklist: mutable.Map[InetAddress, TimeProvider.Time],
+                                  penaltyBook: mutable.Map[InetAddress, (Int, Long)]
+                                )
   extends PeerDatabase with ScorexLogging {
 
   private val safeInterval = settings.penaltySafeInterval.toMillis
 
-  private var peers = Map.empty[InetSocketAddress, (PeerInfo, TimeProvider.Time)]
-
-  /**
-    * banned peer ip -> ban expiration timestamp
-    */
-  private var blacklist = Map.empty[InetAddress, TimeProvider.Time]
-
-  /**
-    * penalized peer ip -> (accumulated penalty score, last penalty timestamp)
-    */
-  private var penaltyBook = Map.empty[InetAddress, (Int, Long)]
-
-  override def get(peer: InetSocketAddress): Option[PeerInfo] = peers.get(peer).map(_._1)
-
-  private def addPeer(peerInfo: PeerInfo): Unit = {
-    peerInfo.peerSpec.address.foreach { address =>
-      log.debug(s"Updating peer info for $address")
-      peers += address -> (peerInfo, timeProvider.time())
-    }
+  override def get(peer: InetSocketAddress): Option[PeerInfo] = bucketManager.getPeer(peer) match {
+    case Some(peerBucketValue) => Some(peerBucketValue.peerInfo)
+    case _ => None
   }
 
   /**
    * Adds a peer to the in-memory database ignoring the configurable limit.
    * Used for high-priority peers, like peers from config file or connected peers
    */
-  override def addOrUpdateKnownPeer(peerInfo: PeerInfo): Unit = {
+  override def addOrUpdateKnownPeer(peerInfo: PeerInfo, source: Option[ConnectedPeer]): Unit = {
     if (!peerInfo.peerSpec.declaredAddress.exists(x => isBlacklisted(x.getAddress))) {
-      addPeer(peerInfo)
+      source match {
+        case Some(source) => bucketManager.addNewPeer(PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true))
+        case None => bucketManager.makeTried(peerInfo.peerSpec.address.getOrElse(throw new IllegalArgumentException()))
+      }
     }
   }
 
-  override def addOrUpdateKnownPeers(peersInfo: Seq[PeerInfo]): Unit = {
+  override def addOrUpdateKnownPeers(peersInfo: Seq[PeerInfo], source: Option[ConnectedPeer]): Unit = {
     val validPeers = peersInfo.filterNot {_.peerSpec.declaredAddress.exists(x => isBlacklisted(x.getAddress))}
-    if (peers.size + validPeers.size > settings.storedPeersLimit) {
-      addOrReplaceOldPeers(validPeers)
-    }
-    else
-      validPeers.foreach(addPeer)
-  }
-
-  private def addOrReplaceOldPeers(validPeers: Seq[PeerInfo]): Unit = {
-    val needToRemove = peers.size + validPeers.size - settings.storedPeersLimit
-    //it can be that all peers are connected, so we won't make enough place
-    val canRemove = peers.toSeq
-      .filter { p => p._2._1.connectionType.isEmpty || p._2._1.lastHandshake == 0 }
-      .sortBy { p => p._2._2 }(Ordering.Long)
-      .take(needToRemove)
-    canRemove
-      .foreach(p => remove(p._1))
-
-    validPeers
-      .take(validPeers.size - (needToRemove - canRemove.size))
-      .foreach(addPeer)
+    validPeers.foreach(peer => addOrUpdateKnownPeer(peer, source))
   }
 
   override def addToBlacklist(socketAddress: InetSocketAddress,
                               penaltyType: PenaltyType): Unit = {
-    peers -= socketAddress
+    remove(socketAddress)
     Option(socketAddress.getAddress).foreach { address =>
       penaltyBook -= address
       if (!blacklist.keySet.contains(address))
@@ -88,10 +65,10 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
   }
 
   override def remove(address: InetSocketAddress): Unit = {
-    peers -= address
+    bucketManager.removePeer(address)
   }
 
-  override def knownPeers: Map[InetSocketAddress, PeerInfo] = peers.transform { (_, info_time) => info_time._1 }
+  override def allPeers: Map[InetSocketAddress, PeerInfo] = bucketManager.getTriedPeers ++ bucketManager.getNewPeers
 
   override def blacklistedPeers: Seq[InetAddress] = blacklist
     .map { case (address, bannedTill) =>
@@ -100,7 +77,7 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
     }
     .toSeq
 
-  override def isEmpty: Boolean = peers.isEmpty
+  override def isEmpty: Boolean = bucketManager.isEmpty
 
   override def isBlacklisted(address: InetAddress): Boolean =
     blacklist.get(address).exists(checkBanned(address, _))
@@ -113,7 +90,7 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
     *
     * @return - `true` if penalty threshold is reached, `false` otherwise.
     */
-  def peerPenaltyScoreOverThreshold(socketAddress: InetSocketAddress, penaltyType: PenaltyType): Boolean =
+  override def peerPenaltyScoreOverThreshold(socketAddress: InetSocketAddress, penaltyType: PenaltyType): Boolean =
     Option(socketAddress.getAddress).exists { address =>
       val (newPenaltyScore, penaltyTs) = penaltyBook.get(address) match {
         case Some((penaltyScoreAcc, lastPenaltyTs)) =>
@@ -156,4 +133,5 @@ final class InMemoryPeerDatabase(settings: NetworkSettings, timeProvider: TimePr
         (360 * 10).days.toMillis
     }
 
+  override def randomPeersSubset: Map[InetSocketAddress, PeerInfo] = bucketManager.getRandomPeers
 }

--- a/src/main/scala/sparkz/core/network/peer/PeerBucketStorage.scala
+++ b/src/main/scala/sparkz/core/network/peer/PeerBucketStorage.scala
@@ -1,0 +1,210 @@
+package sparkz.core.network.peer
+
+import com.google.common.primitives.{Bytes, Ints}
+import scorex.crypto.hash.Blake2b256
+import sparkz.core.network.peer.BucketManager.PeerBucketValue
+import sparkz.core.network.peer.PeerBucketStorage.{BucketConfig, BucketHashContent, NOT_FOUND_PEER_INDEXES}
+import sparkz.core.storage.ScheduledStoragePersister.Persistable
+import sparkz.core.utils.TimeProvider.Time
+import sparkz.core.utils.{NetworkAddressWrapper, TimeProvider}
+
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import scala.collection.mutable
+import scala.util.{Success, Try}
+
+abstract class PeerBucketStorage[T <: BucketHashContent](
+                                  private val bucketConfig: BucketConfig,
+                                  private val nKey: Int,
+                                  private val timeProvider: TimeProvider,
+                                  private val isNewPeer: Boolean
+                                ) {
+  private val (buckets, positionsInBucket, bucketSubgroup) = BucketConfig.unapply(bucketConfig).getOrElse(throw new IllegalArgumentException())
+  private val table: mutable.Map[(Int, Int), (PeerBucketValue, Time)] = mutable.Map.empty[(Int, Int), (PeerBucketValue, Time)]
+  private val reverseTable: mutable.Map[InetSocketAddress, (Int, Int)] = mutable.Map.empty[InetSocketAddress, (Int, Int)]
+
+  protected[peer] def getBucket(hashContent: T): Int = {
+    val hash1Content = Bytes.concat(Ints.toByteArray(nKey), hashContent.getHashAsBytes)
+    val h: Array[Byte] = Blake2b256.hash(hash1Content)
+    val hInt = ByteBuffer.wrap(h).getInt
+
+    val hash2Content = Bytes.concat(Ints.toByteArray(nKey), getAddressGroup(hashContent.getAddress), Ints.toByteArray(hInt % bucketSubgroup))
+    val hash2: Array[Byte] = Blake2b256.hash(hash2Content)
+
+    ByteBuffer.wrap(hash2).getInt % buckets
+  }
+
+  private def getAddressGroup(peerAddress: InetSocketAddress): Array[Byte] = {
+    val na = new NetworkAddressWrapper(peerAddress)
+    var nClass = NetworkAddressWrapper.NET_IPV6
+    var nStartByte = 0
+    var nBits = 16
+
+    if (na.isLocal) {
+      nClass = 255
+      nBits = 0
+    } else if (!na.isRoutable) {
+      nClass = NetworkAddressWrapper.NET_UNROUTABLE
+      nBits = 0
+    } else if (na.hasLinkedIPv4) {
+      nClass = NetworkAddressWrapper.NET_IPV4
+    } else if (na.isHeNet) {
+      nBits = 36
+    }
+    else
+      nBits = 32
+
+    var result: Array[Byte] = Array(nClass.toByte)
+    while (nBits >= 16) {
+      result = result ++ na.getSubNum(nStartByte)
+      nStartByte += 1
+      nBits -= 16
+    }
+    result
+  }
+
+  protected[peer] def getBucketPosition(nBucket: Int, peerAddress: InetSocketAddress): Int = {
+    val hashContent = Bytes.concat(
+      Ints.toByteArray(nKey),
+      Ints.toByteArray(if (isNewPeer) 1 else 0),
+      Ints.toByteArray(nBucket),
+      peerAddress.getHostString.getBytes,
+      Ints.toByteArray(peerAddress.getPort)
+    )
+    val hash1 = Blake2b256.hash(hashContent)
+    ByteBuffer.wrap(hash1).getInt % positionsInBucket
+  }
+
+  def add(peerBucketValue: PeerBucketValue): Unit = {
+    peerBucketValue.peerInfo.peerSpec.address.foreach(address => {
+      val hashContent = getHashContent(peerBucketValue)
+      val (bucket, bucketPosition) = getPeerIndexes(hashContent)
+      table += (bucket, bucketPosition) -> (peerBucketValue, timeProvider.time())
+      reverseTable += address -> (bucket, bucketPosition)
+    })
+  }
+
+  protected def getHashContent(peerBucketValue: PeerBucketValue): T
+
+  def remove(address: InetSocketAddress): Unit = {
+    val peerIndexes = tryGetIndexesFromPeerAddress(address)
+
+    if (peerIndexes != NOT_FOUND_PEER_INDEXES) {
+      table -= ((peerIndexes._1, peerIndexes._2))
+      reverseTable -= address
+    }
+  }
+
+  def bucketPositionIsAlreadyTaken(peerBucketValue: PeerBucketValue): Boolean = {
+    val hashContent = getHashContent(peerBucketValue)
+    val (bucket, bucketPosition) = getPeerIndexes(hashContent)
+
+    table.contains((bucket, bucketPosition))
+  }
+
+  def contains(address: InetSocketAddress): Boolean = {
+    tryGetIndexesFromPeerAddress(address) != NOT_FOUND_PEER_INDEXES
+  }
+
+  def getStoredPeerByAddress(address: InetSocketAddress): Option[PeerBucketValue] = {
+    tryGetIndexesFromPeerAddress(address) match {
+      case indexes if indexes != NOT_FOUND_PEER_INDEXES => Some(table(indexes._1, indexes._2)._1)
+      case _ => None
+    }
+  }
+
+  def getStoredPeerByIndexes(bucket: Int, bucketPosition: Int): Option[PeerBucketValue] = {
+    Try(table(bucket, bucketPosition)) match {
+      case Success((peerBucketValue, _)) => Some(peerBucketValue)
+      case _ => None
+    }
+  }
+
+  def getPeerIndexes(peerBucketValue: PeerBucketValue): (Int, Int) = {
+    val peerHashContent = getHashContent(peerBucketValue)
+    getPeerIndexes(peerHashContent)
+  }
+
+  def getPeerIndexes(peerHashContent: T): (Int, Int) = {
+    val bucket = getBucket(peerHashContent)
+    val bucketPosition = getBucketPosition(bucket, peerHashContent.getAddress)
+    (bucket, bucketPosition)
+  }
+
+  private def tryGetIndexesFromPeerAddress(address: InetSocketAddress): (Int, Int) = {
+    Try(reverseTable(address)) match {
+      case Success(indexes) => indexes
+      case _ => NOT_FOUND_PEER_INDEXES
+    }
+  }
+
+  def isEmpty: Boolean = table.isEmpty
+
+  def nonEmpty: Boolean = !isEmpty
+
+  def getPeers: Map[InetSocketAddress, PeerInfo] =
+    table
+      .values
+      .map { p => (p._1.peerInfo.peerSpec.address.getOrElse(throw new IllegalArgumentException()), p._1.peerInfo) }
+      .toMap
+
+  def getPeersAsBucketValue: Seq[PeerBucketValue] = table.values.map(value => value._1).toSeq
+
+  def clear(): Unit = {
+    table.clear()
+    reverseTable.clear()
+  }
+}
+
+object PeerBucketStorage {
+  val NOT_FOUND_PEER_INDEXES: (Int, Int) = (-1, -1)
+  case class BucketConfig(buckets: Int, bucketPositions: Int, bucketSubgroups: Int)
+
+  trait BucketHashContent {
+    def getAddress: InetSocketAddress
+
+    def getHashAsBytes: Array[Byte]
+  }
+
+  case class NewPeerBucketHashContent(address: InetSocketAddress, sourceAddress: InetSocketAddress) extends BucketHashContent {
+    override def getHashAsBytes: Array[Byte] = Bytes.concat(
+      address.getHostString.getBytes,
+      Ints.toByteArray(address.getPort),
+      sourceAddress.getHostString.getBytes,
+      Ints.toByteArray(sourceAddress.getPort)
+    )
+
+    override def getAddress: InetSocketAddress = address
+  }
+
+  case class TriedPeerBucketHashContent(address: InetSocketAddress) extends BucketHashContent {
+
+    override def getHashAsBytes: Array[Byte] = Bytes.concat(address.getHostString.getBytes, Ints.toByteArray(address.getPort))
+
+    override def getAddress: InetSocketAddress = address
+  }
+
+  case class NewPeerBucketStorage(bucketConfig: BucketConfig, nKey: Int, timeProvider: TimeProvider)
+    extends PeerBucketStorage[NewPeerBucketHashContent](bucketConfig, nKey, timeProvider, true)
+    with Persistable {
+
+    override protected def getHashContent(peerBucketValue: PeerBucketValue): NewPeerBucketHashContent = {
+      val address = peerBucketValue.peerInfo.peerSpec.address.getOrElse(throw new IllegalArgumentException())
+      NewPeerBucketHashContent(address, peerBucketValue.source.connectionId.remoteAddress)
+    }
+
+    override val STORAGE_LABEL: String = "NewBucketPeers.dat"
+  }
+
+  case class TriedPeerBucketStorage(bucketConfig: BucketConfig, nKey: Int, timeProvider: TimeProvider)
+    extends PeerBucketStorage[TriedPeerBucketHashContent](bucketConfig, nKey, timeProvider, false)
+    with Persistable {
+
+    override protected def getHashContent(peerBucketValue: PeerBucketValue): TriedPeerBucketHashContent = {
+      val address = peerBucketValue.peerInfo.peerSpec.address.getOrElse(throw new IllegalArgumentException())
+      TriedPeerBucketHashContent(address)
+    }
+
+    override val STORAGE_LABEL: String = "TriedBucketPeers.dat"
+  }
+}

--- a/src/main/scala/sparkz/core/network/peer/PeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/PeerDatabase.scala
@@ -1,5 +1,7 @@
 package sparkz.core.network.peer
 
+import sparkz.core.network.ConnectedPeer
+
 import java.net.{InetAddress, InetSocketAddress}
 
 trait PeerDatabase {
@@ -12,12 +14,15 @@ trait PeerDatabase {
     * Add peer to the database, or update it
     *
     * @param peerInfo - peer record
+    * @param source - the peer that sent the peerInfo
     */
-  def addOrUpdateKnownPeer(peerInfo: PeerInfo): Unit
+  def addOrUpdateKnownPeer(peerInfo: PeerInfo, source: Option[ConnectedPeer]): Unit
 
-  def addOrUpdateKnownPeers(peersInfo: Seq[PeerInfo]): Unit
+  def addOrUpdateKnownPeers(peersInfo: Seq[PeerInfo], source: Option[ConnectedPeer]): Unit
 
-  def knownPeers: Map[InetSocketAddress, PeerInfo]
+  def allPeers: Map[InetSocketAddress, PeerInfo]
+
+  def randomPeersSubset: Map[InetSocketAddress, PeerInfo]
 
   def addToBlacklist(address: InetSocketAddress, penaltyType: PenaltyType): Unit
 
@@ -28,4 +33,6 @@ trait PeerDatabase {
   def isBlacklisted(address: InetAddress): Boolean
 
   def remove(address: InetSocketAddress): Unit
+
+  def peerPenaltyScoreOverThreshold(peer: InetSocketAddress, penaltyType: PenaltyType): Boolean
 }

--- a/src/main/scala/sparkz/core/network/peer/PeerManager.scala
+++ b/src/main/scala/sparkz/core/network/peer/PeerManager.scala
@@ -15,18 +15,18 @@ import java.security.SecureRandom
   * Peer manager takes care of peers connected and in process, and also chooses a random peer to connect
   * Must be singleton
   */
-class PeerManager(settings: SparkzSettings, sparkzContext: SparkzContext) extends Actor with ScorexLogging {
+class PeerManager(settings: SparkzSettings, sparkzContext: SparkzContext, peerDatabase: PeerDatabase) extends Actor with ScorexLogging {
 
   import PeerManager.ReceivableMessages._
 
-  private val peerDatabase = new InMemoryPeerDatabase(settings.network, sparkzContext.timeProvider)
+  private var knownPeers: Map[InetSocketAddress, PeerInfo] = Map.empty
   private val knownPeersSet: Set[InetSocketAddress] = settings.network.knownPeers.toSet
 
   if (peerDatabase.isEmpty) {
     // fill database with peers from config file if empty
     knownPeersSet.foreach { address =>
       if (!isSelf(address)) {
-        peerDatabase.addOrUpdateKnownPeer(PeerInfo.fromAddress(address))
+        knownPeers += address -> PeerInfo.fromAddress(address)
       }
     }
   }
@@ -40,12 +40,12 @@ class PeerManager(settings: SparkzSettings, sparkzContext: SparkzContext) extend
 
     case ConfirmConnection(connectionId, handlerRef) =>
       log.info(s"Connection confirmation request: $connectionId")
-      if (peerDatabase.isBlacklisted(connectionId.remoteAddress)) sender() ! ConnectionDenied(connectionId, handlerRef)
+      if (peerDatabase.isBlacklisted(connectionId.remoteAddress.getAddress)) sender() ! ConnectionDenied(connectionId, handlerRef)
       else sender() ! ConnectionConfirmed(connectionId, handlerRef)
 
-    case AddOrUpdatePeer(peerInfo) =>
+    case AddOrUpdatePeer(peerInfo, source) =>
       // We have connected to a peer and got his peerInfo from him
-      if (!isSelf(peerInfo.peerSpec)) peerDatabase.addOrUpdateKnownPeer(peerInfo)
+      if (!isSelf(peerInfo.peerSpec)) peerDatabase.addOrUpdateKnownPeer(peerInfo, source)
 
     case Penalize(peer, penaltyType) =>
       log.info(s"$peer penalized, penalty: $penaltyType")
@@ -55,7 +55,7 @@ class PeerManager(settings: SparkzSettings, sparkzContext: SparkzContext) extend
         sender() ! Blacklisted(peer)
       }
 
-    case AddPeersIfEmpty(peersSpec) =>
+    case AddPeersIfEmpty(peersSpec, source) =>
       // We have received peers data from other peers. It might be modified and should not affect existing data if any
       val filteredPeers = peersSpec
         .collect {
@@ -64,23 +64,24 @@ class PeerManager(settings: SparkzSettings, sparkzContext: SparkzContext) extend
             log.info(s"New discovered peer: $peerInfo")
             peerInfo
         }
-      peerDatabase.addOrUpdateKnownPeers(filteredPeers)
+      peerDatabase.addOrUpdateKnownPeers(filteredPeers, Some(source))
 
     case RemovePeer(address) =>
-      if (!knownPeersSet(address)) {
-        peerDatabase.remove(address)
-        log.info(s"$address removed from peers database")
-      }
+      peerDatabase.remove(address)
+      log.info(s"$address removed from peers database")
+
+    case get: RandomPeerForConnectionExcluding =>
+      sender() ! get.choose(knownPeers, peerDatabase.randomPeersSubset, peerDatabase.blacklistedPeers, sparkzContext)
 
     case get: GetPeers[_] =>
-      sender() ! get.choose(peerDatabase.knownPeers, peerDatabase.blacklistedPeers, sparkzContext)
+      sender() ! get.choose(knownPeers, peerDatabase.allPeers, peerDatabase.blacklistedPeers, sparkzContext)
   }
 
   private def apiInterface: Receive = {
 
     case GetAllPeers =>
-      log.trace(s"Get all peers: ${peerDatabase.knownPeers}")
-      sender() ! peerDatabase.knownPeers
+      log.trace(s"Get all peers: ${peerDatabase.allPeers}")
+      sender() ! peerDatabase.allPeers
 
     case GetBlacklistedPeers =>
       sender() ! peerDatabase.blacklistedPeers
@@ -114,9 +115,13 @@ object PeerManager {
     case class Blacklisted(remote: InetSocketAddress)
 
     // peerListOperations messages
-    case class AddOrUpdatePeer(data: PeerInfo)
+    /**
+      * @param data: information about peer to be stored in PeerDatabase
+      * @param source: if the source is set, it means is a new peer, otherwise it's a peer to be moved into the tried
+      * */
+    case class AddOrUpdatePeer(data: PeerInfo, source: Option[ConnectedPeer] = None)
 
-    case class AddPeersIfEmpty(data: Seq[PeerSpec])
+    case class AddPeersIfEmpty(data: Seq[PeerSpec], source: ConnectedPeer)
 
     case class RemovePeer(address: InetSocketAddress)
 
@@ -125,6 +130,7 @@ object PeerManager {
       */
     trait GetPeers[T] {
       def choose(knownPeers: Map[InetSocketAddress, PeerInfo],
+                 peers: Map[InetSocketAddress, PeerInfo],
                  blacklistedPeers: Seq[InetAddress],
                  sparkzContext: SparkzContext): T
     }
@@ -137,42 +143,63 @@ object PeerManager {
     case class SeenPeers(howMany: Int) extends GetPeers[Seq[PeerInfo]] {
 
       override def choose(knownPeers: Map[InetSocketAddress, PeerInfo],
+                          peers: Map[InetSocketAddress, PeerInfo],
                           blacklistedPeers: Seq[InetAddress],
                           sparkzContext: SparkzContext): Seq[PeerInfo] = {
-        val recentlySeenNonBlacklisted = knownPeers.values.toSeq
+        val recentlySeenKnownPeers = knownPeers.values.toSeq
+          .filter { p =>
+            (p.connectionType.isDefined || p.lastHandshake > 0)
+          }
+        val recentlySeenNonBlacklisted = peers.values.toSeq
           .filter { p =>
             (p.connectionType.isDefined || p.lastHandshake > 0) &&
               !blacklistedPeers.exists(ip => p.peerSpec.declaredAddress.exists(_.getAddress == ip))
           }
-        Random.shuffle(recentlySeenNonBlacklisted).take(howMany)
+        Random.shuffle(recentlySeenKnownPeers ++ recentlySeenNonBlacklisted).take(howMany)
       }
     }
 
     case object GetAllPeers extends GetPeers[Map[InetSocketAddress, PeerInfo]] {
 
       override def choose(knownPeers: Map[InetSocketAddress, PeerInfo],
+                          peers: Map[InetSocketAddress, PeerInfo],
                           blacklistedPeers: Seq[InetAddress],
-                          sparkzContext: SparkzContext): Map[InetSocketAddress, PeerInfo] = knownPeers
+                          sparkzContext: SparkzContext): Map[InetSocketAddress, PeerInfo] = knownPeers ++ peers
     }
 
-    case class RandomPeerExcluding(excludedPeers: Seq[Option[InetSocketAddress]]) extends GetPeers[Option[PeerInfo]] {
+    case class RandomPeerForConnectionExcluding(excludedPeers: Seq[Option[InetSocketAddress]]) extends GetPeers[Option[PeerInfo]] {
       private val secureRandom = new SecureRandom()
 
       override def choose(knownPeers: Map[InetSocketAddress, PeerInfo],
+                          peers: Map[InetSocketAddress, PeerInfo],
                           blacklistedPeers: Seq[InetAddress],
                           sparkzContext: SparkzContext): Option[PeerInfo] = {
-        val candidates = knownPeers.values.filterNot { p =>
-          excludedPeers.contains(p.peerSpec.address) ||
-            blacklistedPeers.exists(addr => p.peerSpec.address.map(_.getAddress).contains(addr))
+        var response: Option[PeerInfo] = None
+
+        val knownPeersCandidates = knownPeers.values.filterNot { p =>
+          excludedPeers.contains(p.peerSpec.address)
         }.toSeq
-        if (candidates.nonEmpty) Some(candidates(secureRandom.nextInt(candidates.size)))
-        else None
+
+        if (knownPeersCandidates.nonEmpty) {
+          response = Some(knownPeersCandidates(secureRandom.nextInt(knownPeersCandidates.size)))
+        } else {
+          val candidates = peers.values.filterNot { p =>
+            excludedPeers.contains(p.peerSpec.address) ||
+              blacklistedPeers.exists(addr => p.peerSpec.address.map(_.getAddress).contains(addr))
+          }.toSeq
+
+          if (candidates.nonEmpty)
+            response = Some(candidates(secureRandom.nextInt(candidates.size)))
+        }
+
+        response
       }
     }
 
     case object GetBlacklistedPeers extends GetPeers[Seq[InetAddress]] {
 
       override def choose(knownPeers: Map[InetSocketAddress, PeerInfo],
+                          peers: Map[InetSocketAddress, PeerInfo],
                           blacklistedPeers: Seq[InetAddress],
                           sparkzContext: SparkzContext): Seq[InetAddress] = blacklistedPeers
     }
@@ -183,18 +210,18 @@ object PeerManager {
 
 object PeerManagerRef {
 
-  def props(settings: SparkzSettings, sparkzContext: SparkzContext): Props = {
-    Props(new PeerManager(settings, sparkzContext))
+  def props(settings: SparkzSettings, sparkzContext: SparkzContext, peerDatabase: PeerDatabase): Props = {
+    Props(new PeerManager(settings, sparkzContext, peerDatabase))
   }
 
-  def apply(settings: SparkzSettings, sparkzContext: SparkzContext)
+  def apply(settings: SparkzSettings, sparkzContext: SparkzContext, peerDatabase: PeerDatabase)
            (implicit system: ActorSystem): ActorRef = {
-    system.actorOf(props(settings, sparkzContext))
+    system.actorOf(props(settings, sparkzContext, peerDatabase))
   }
 
-  def apply(name: String, settings: SparkzSettings, sparkzContext: SparkzContext)
+  def apply(name: String, settings: SparkzSettings, sparkzContext: SparkzContext, peerDatabase: PeerDatabase)
            (implicit system: ActorSystem): ActorRef = {
-    system.actorOf(props(settings, sparkzContext), name)
+    system.actorOf(props(settings, sparkzContext, peerDatabase), name)
   }
 
 }

--- a/src/main/scala/sparkz/core/settings/Settings.scala
+++ b/src/main/scala/sparkz/core/settings/Settings.scala
@@ -50,6 +50,8 @@ case class NetworkSettings(nodeName: String,
                            getPeersInterval: FiniteDuration,
                            maxPeerSpecObjects: Int,
                            storedPeersLimit: Int,
+                           storageBackupInterval: FiniteDuration,
+                           storageBackupDelay: FiniteDuration,
                            temporalBanDuration: FiniteDuration,
                            penaltySafeInterval: FiniteDuration,
                            penaltyScoreThreshold: Int)

--- a/src/main/scala/sparkz/core/storage/ScheduledActor.scala
+++ b/src/main/scala/sparkz/core/storage/ScheduledActor.scala
@@ -1,0 +1,38 @@
+package sparkz.core.storage
+
+import akka.actor.{ActorSystem, Cancellable}
+import sparkz.core.storage.ScheduledActor.ScheduledActorConfig
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * An abstract class representing an actor that runs a scheduled job
+  *
+  * @param config - The scheduled job configuration
+  * @param ec     - The actor's execution context
+  */
+abstract class ScheduledActor(private val config: ScheduledActorConfig)(implicit ec: ExecutionContext) {
+  private val (initialDelay, scheduleInterval) = ScheduledActorConfig.unapply(config).getOrElse(throw new IllegalArgumentException())
+  private val job: Cancellable = ActorSystem("scheduledActor").scheduler.scheduleWithFixedDelay(initialDelay, scheduleInterval) {
+    () => scheduledJob()
+  }
+
+  /**
+    * Method to cancel the current job
+    *
+    * @return - Whether the job is cancelled successfully
+    */
+  def stopJob: Boolean = job.cancel()
+
+  /**
+    * The custom job the actor should run
+    */
+  protected def scheduledJob(): Unit
+}
+
+object ScheduledActor {
+
+  case class ScheduledActorConfig(initialDelay: FiniteDuration, scheduleInterval: FiniteDuration)
+
+}

--- a/src/main/scala/sparkz/core/storage/StoragePersister.scala
+++ b/src/main/scala/sparkz/core/storage/StoragePersister.scala
@@ -1,0 +1,179 @@
+package sparkz.core.storage
+
+import sparkz.core.network.peer.BucketManager.PeerBucketValue
+import sparkz.core.network.peer.PeerBucketStorage
+import sparkz.core.storage.ScheduledActor.ScheduledActorConfig
+import sparkz.core.storage.ScheduledStorageFilePersister.ScheduledStorageFilePersisterConfig
+import sparkz.core.storage.ScheduledStoragePersister.ScheduledStoragePersisterConfig
+
+import java.io._
+import java.nio.file.{Files, Paths}
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
+/**
+  * This abstract class represents an actor that is responsible to persist and recover data
+  *
+  * @param config The scheduled job configuration
+  * @param ec     The actor's execution context
+  * @tparam D The type of the data stored
+  */
+abstract class ScheduledStoragePersister[D](private val config: ScheduledStoragePersisterConfig)(implicit ec: ExecutionContext)
+  extends ScheduledActor(config.scheduledActorConfig) {
+
+  /**
+    * Custom method that returns the data to persist as byte array
+    *
+    * @return The data to be stored as byte array
+    */
+  protected def getDataToPersist: Array[Byte]
+
+  /**
+    * Custom method that returns the specific output stream the class wants to use to write the data
+    *
+    * @return The output stream to write the data
+    */
+  protected def getOutputStream: OutputStream
+
+  /**
+    * Custom method to retrieve data to restore from the specified source
+    *
+    * @return The stored data as an array of bytes
+    */
+  protected def tryGetSourceDataToRestore: Try[Array[Byte]]
+
+  /**
+    * Custom method to restore the data into the data structure
+    */
+  def restore(): Unit
+
+  /**
+    * This class always runs the persist method as a scheduled job
+    */
+  override protected def scheduledJob(): Unit = persist()
+
+  /**
+    * Persist data using the custom output stream
+    */
+  def persist(): Unit = {
+    val dataToPersist: Array[Byte] = getDataToPersist
+    val bos = new BufferedOutputStream(getOutputStream)
+    bos.write(dataToPersist)
+    bos.close()
+  }
+
+  /**
+    * Retrieve the data previously stored and return them
+    *
+    * @return The data previously stored as an Option
+    */
+  def recoverStoredData: Option[D] = {
+    tryGetSourceDataToRestore match {
+      case Success(bytes) =>
+        val ois = new ObjectInputStream(new ByteArrayInputStream(bytes))
+        val value = ois.readObject
+        ois.close()
+        Some(value.asInstanceOf[D])
+      case Failure(_) => None
+    }
+  }
+}
+
+object ScheduledStoragePersister {
+  case class ScheduledStoragePersisterConfig(scheduledActorConfig: ScheduledActorConfig)
+
+  trait Persistable {
+    val STORAGE_LABEL: String
+  }
+}
+
+/**
+  * This abstract class writes and reads from file
+  *
+  * @param config The scheduled job configuration
+  * @param ec     The actor's execution context
+  * @tparam T The type of the data structure holding the data to persist
+  * @tparam D The type of the data stored
+  */
+abstract class ScheduledStorageFilePersister[T, D](private val config: ScheduledStorageFilePersisterConfig)(implicit ec: ExecutionContext)
+  extends ScheduledStoragePersister[D](config.scheduledStoragePersisterConfig) {
+
+  private val absolutePath = Paths.get(config.directoryPath.getPath, config.fileName)
+
+  override protected def getOutputStream: OutputStream = new FileOutputStream(absolutePath.toFile)
+
+  override protected def tryGetSourceDataToRestore: Try[Array[Byte]] = Try(Files.readAllBytes(absolutePath))
+}
+
+object ScheduledStorageFilePersister {
+  case class ScheduledStorageFilePersisterConfig(
+                                                  directoryPath: File,
+                                                  fileName: String,
+                                                  scheduledStoragePersisterConfig: ScheduledStoragePersisterConfig)
+}
+
+/**
+  * This class is responsible to persist any PeerBucketStorage
+  *
+  * @param peerBucketStorage The PeerBucketStorage data structure to backup
+  * @param config            The scheduled job configuration
+  * @param ec                The actor's execution context
+  * @tparam T The type of the data structure holding the data to persist
+  */
+class ScheduledPeerBucketPersister[T <: PeerBucketStorage[_]](
+                                                               private val peerBucketStorage: T,
+                                                               private val config: ScheduledStorageFilePersisterConfig
+                                                             )(implicit ec: ExecutionContext)
+  extends ScheduledStorageFilePersister[T, Seq[PeerBucketValue]](config) {
+
+  override protected def getDataToPersist: Array[Byte] = {
+    val peers = peerBucketStorage.getPeersAsBucketValue
+
+    val stream: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(stream)
+    oos.writeObject(peers)
+    oos.close()
+    stream.toByteArray
+  }
+
+  override def restore(): Unit = {
+    val storedData = recoverStoredData
+    storedData match {
+      case Some(peersList) => peersList.foreach(peer => peerBucketStorage.add(peer))
+      case None =>
+    }
+  }
+}
+
+/**
+  * This class is responsible to persist any Map
+  *
+  * @param storage The map data structure to backup
+  * @param config  The scheduled job configuration
+  * @param ec      The actor's execution context
+  * @tparam K The type of the map's keys
+  * @tparam V The type of the map's values
+  */
+class ScheduledMapPersister[K, V](
+                                   private val storage: mutable.Map[K, V],
+                                   private val config: ScheduledStorageFilePersisterConfig
+                                 )(implicit ec: ExecutionContext)
+  extends ScheduledStorageFilePersister[mutable.Map[K, V], mutable.Map[K, V]](config) {
+
+  override protected def getDataToPersist: Array[Byte] = {
+    val stream: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(stream)
+    oos.writeObject(storage)
+    oos.close()
+    stream.toByteArray
+  }
+
+  override def restore(): Unit = {
+    val storedData = recoverStoredData
+    storedData match {
+      case Some(entries) => entries.foreach(entry => storage += entry._1 -> entry._2)
+      case None =>
+    }
+  }
+}

--- a/src/main/scala/sparkz/core/storage/StoragePersisterContainer.scala
+++ b/src/main/scala/sparkz/core/storage/StoragePersisterContainer.scala
@@ -1,0 +1,23 @@
+package sparkz.core.storage
+
+import sparkz.core.storage.StoragePersisterContainer.StoragePersisterContainerConfig
+
+import java.io.File
+import java.nio.file.Files
+
+class StoragePersisterContainer(
+                                 private val scheduledStoragePersister: Seq[ScheduledStoragePersister[_]],
+                                 private val config: StoragePersisterContainerConfig
+                               ) {
+  initDirectoryForAllStorages()
+
+  private def initDirectoryForAllStorages(): Unit = {
+    Files.createDirectories(config.directoryPath.toPath)
+  }
+
+  def restoreAllStorages(): Unit = scheduledStoragePersister.foreach(persister => persister.restore())
+}
+
+object StoragePersisterContainer {
+  case class StoragePersisterContainerConfig(directoryPath: File)
+}

--- a/src/main/scala/sparkz/core/utils/NetworkAddressWrapper.scala
+++ b/src/main/scala/sparkz/core/utils/NetworkAddressWrapper.scala
@@ -1,0 +1,121 @@
+package sparkz.core.utils
+
+import java.net.{Inet4Address, Inet6Address, InetSocketAddress}
+
+class NetworkAddressWrapper(address: InetSocketAddress) {
+  private val stringAddr = if (isIPv4) address.getHostString.split('.')
+                           else address.getAddress.getHostAddress.split(':')
+
+  def isLocal: Boolean = NetworkUtils.isLocalAddress(address.getAddress)
+  def isRoutable: Boolean = {
+    !(isRFC1918 || isRFC2544 || isRFC3927 || isRFC6598 || isRFC5737 || isLocal)
+  }
+  def isIPv4: Boolean = address.getAddress match {
+    case _: Inet4Address => true
+    case _ => false
+  }
+  def isIPv6: Boolean = address.getAddress match {
+    case _: Inet6Address => true
+    case _ => false
+  }
+
+  def hasLinkedIPv4: Boolean = {
+    isRoutable && (isIPv4 || isRFC6145 || isRFC6052 || isRFC3964 || isRFC4380)
+  }
+
+  private def isBetween(str: String, lower: Int, higher: Int): Boolean = {
+    val num = str.toInt
+    num >= lower && num <= higher
+  }
+
+  // IPv4 private networks (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
+  def isRFC1918: Boolean = {
+    isIPv4 && (
+      stringAddr(0) == "10" ||
+        (stringAddr(0) == "192" && stringAddr(1) == "168") ||
+        (stringAddr(0) == "172" && isBetween(stringAddr(1), 16, 31))
+      )
+  }
+
+  // IPv4 inter-network communications (192.18.0.0/15)
+  def isRFC2544: Boolean = {
+    isIPv4 && (
+      stringAddr(0) == "198" && isBetween(stringAddr(1), 18, 19)
+    )
+  }
+
+  // IPv4 ISP-level NAT (100.64.0.0/10)
+  def isRFC6598: Boolean = {
+    isIPv4 && (
+      stringAddr(0) == "100" && isBetween(stringAddr(1), 64, 127)
+    )
+  }
+
+  // IPv4 documentation addresses (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24)
+  def isRFC5737: Boolean = {
+    isIPv4 && (
+      (stringAddr(0) == "192" && stringAddr(1) == "0" && stringAddr(2) == "2") ||
+        (stringAddr(0) == "198" && stringAddr(1) == "51" && stringAddr(2) == "100") ||
+        (stringAddr(0) == "203" && stringAddr(1) == "0" && stringAddr(2) == "113")
+    )
+  }
+
+  // IPv4 autoconfig (169.254.0.0/16)
+  def isRFC3927: Boolean = {
+    isIPv4 && (stringAddr(0) == "169" && stringAddr(1) == "254")
+  }
+
+  // IPv6 documentation address (2001:0DB8::/32)
+  def isRFC3849: Boolean = {
+    isIPv6 && stringAddr(0) == "2001" && stringAddr(1) == "0db8"
+  }
+
+  // IPv6 6to4 tunnelling (2002::/16)
+  def isRFC3964: Boolean = {
+    isIPv6 && stringAddr(0) == "2002"
+  }
+
+  // IPv6 unique local (FC00::/7)
+  def isRFC4193: Boolean = {
+    isIPv6 && stringAddr(0) == "fc00"
+  }
+
+  // IPv6 Teredo tunnelling (2001::/32)
+  def isRFC4380: Boolean = {
+    isIPv6 && stringAddr(0) == "2001" && stringAddr(1) == "0"
+  }
+
+  // IPv6 ORCHID (2001:10::/28)
+  def isRFC4843: Boolean = {
+    isIPv6 && stringAddr(0) == "2001" && stringAddr(1) == "10"
+  }
+
+  // IPv6 autoconfig (FE80::/64)
+  def isRFC4862: Boolean = {
+    isIPv6 && stringAddr(0) == "fe80"
+  }
+
+  // IPv6 well-known prefix (64:FF9B::/96)
+  def isRFC6052: Boolean = {
+    isIPv6 && stringAddr(0) == "64" && stringAddr(1) == "ff9b"
+  }
+
+  // IPv6 IPv4-translated address (::FFFF:0:0:0/96)
+  def isRFC6145: Boolean = {
+    isIPv6 && stringAddr(3) == "ffff"
+  }
+
+  def isHeNet: Boolean = {
+    isIPv6 && stringAddr(0) == "2001" && stringAddr(1) == "470"
+  }
+
+  def getSubNum(index: Int): Array[Byte] = {
+    stringAddr(index).getBytes
+  }
+}
+
+object NetworkAddressWrapper extends Enumeration {
+  val NET_UNROUTABLE: Int = 0
+  val NET_IPV4: Int = 1
+  val NET_IPV6: Int = 2
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -62,11 +62,14 @@ sparkz {
     # distinguish different networks (e.g. testnet/mainnet).
     magicBytes = [12, 34, 56, 78]
 
-    # String with IP address and port to send as external address during handshake. 
+    # max message size = 16 * 1024 * 1024
+    messageLengthBytesLimit = 16777216
+
+    # String with IP address and port to send as external address during handshake.
     #
-    # If `declared-address` is set, which is the common scenario for nodes running in the cloud, 
-    # the node will just listen to incoming connections on `bindAddress:port` and 
-    # broadcast its `declaredAddress` to its peers. 
+    # If `declared-address` is set, which is the common scenario for nodes running in the cloud,
+    # the node will just listen to incoming connections on `bindAddress:port` and
+    # broadcast its `declaredAddress` to its peers.
     #
     # If declared address is not set, the node will not listen to incoming connections at all.
     # declaredAddress = ""
@@ -84,6 +87,9 @@ sparkz {
     # Network handshake timeout
     handshakeTimeout = 30s
 
+    # List of IP addresses of well known nodes.
+    knownPeers = []
+
     # Interval between GetPeers messages to be send by our node to a random one
     getPeersInterval = 2m
 
@@ -97,6 +103,16 @@ sparkz {
     connectionTimeout = 1s
 
     ############################
+    # Peers' storages settings #
+    ############################
+
+    # Interval to backup peers' storages
+    storageBackupInterval = 15m
+
+    # Delay to start peers' backup
+    storageBackupDelay = 5m
+
+    ############################
     # Delivery settings limits #
     ############################
 
@@ -106,6 +122,9 @@ sparkz {
     # Max number of delivery checks for a persistent modifier.
     # Stop expecting modifier (and penalize peer) if it was not delivered on time.
     maxDeliveryChecks = 2
+
+    # Penalize remote peers not answering to our requests during in the RequestTracker
+    penalizeNonDelivery = true
 
     ############
     # Timeouts #
@@ -145,6 +164,9 @@ sparkz {
     # Accept maximum inv objects
     maxInvObjects = 512
 
+    # Limit for number of modifiers to request and process at once
+    maxRequestedPerPeer = 1024
+
     # Desired number of inv objects. Our requests will have this size.
     desiredInvObjects = 512
 
@@ -154,6 +176,9 @@ sparkz {
 
     # Maximum number of PeerSpec objects in one Peers message
     maxPeerSpecObjects = 64
+
+    # Maximum number of PeerSpec objects stored in the in-memory database
+    storedPeersLimit = 1024
 
     # Default ban duration, unless permanent penalty is applied
     temporalBanDuration = 60m

--- a/src/test/scala/sparkz/core/network/NetworkControllerSpec.scala
+++ b/src/test/scala/sparkz/core/network/NetworkControllerSpec.scala
@@ -14,12 +14,14 @@ import sparkz.core.app.{SparkzContext, Version}
 import sparkz.core.network.NetworkController.ReceivableMessages.Internal.ConnectionToPeer
 import sparkz.core.network.NetworkController.ReceivableMessages.{ConnectTo, GetConnectedPeers, GetPeersStatus}
 import sparkz.core.network.message._
+import sparkz.core.network.peer.PeerBucketStorage.{BucketConfig, NewPeerBucketStorage, TriedPeerBucketStorage}
 import sparkz.core.network.peer.PeerManager.ReceivableMessages.AddOrUpdatePeer
 import sparkz.core.network.peer._
 import sparkz.core.settings.SparkzSettings
 import sparkz.core.utils.LocalTimeProvider
 
-import java.net.{InetAddress, InetSocketAddress}
+import java.net.InetSocketAddress
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.language.postfixOps
 
@@ -30,7 +32,7 @@ class NetworkControllerSpec extends NetworkTests {
   private val featureSerializers = Map(LocalAddressPeerFeature.featureId -> LocalAddressPeerFeatureSerializer)
 
   "A NetworkController" should "send local address on handshake when peer and node address are in localhost" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
     val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe)
@@ -49,7 +51,7 @@ class NetworkControllerSpec extends NetworkTests {
   }
 
   it should "send local address on handshake when the peer are in local network" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
     val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe)
@@ -67,7 +69,7 @@ class NetworkControllerSpec extends NetworkTests {
   }
 
   it should "not send local address on handshake when the peer is external" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
     val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe)
@@ -86,7 +88,7 @@ class NetworkControllerSpec extends NetworkTests {
   }
 
   it should "send declared address when node and peer are public" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
 
@@ -107,15 +109,19 @@ class NetworkControllerSpec extends NetworkTests {
   }
 
   it should "send known public peers" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
 
     val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
     val settings2 = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
-    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, peerManager: ActorRef) = createNetworkController(settings2, tcpManagerProbe)
     val testPeer1 = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
     val peer1Addr = new InetSocketAddress("88.77.66.55", 5678)
+
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    peerManager ! AddOrUpdatePeer(getPeerInfo(peer1Addr), Some(source))
+
     testPeer1.connectAndExpectSuccessfulMessages(peer1Addr, nodeAddr, Tcp.ResumeReading)
     testPeer1.receiveHandshake
     testPeer1.sendHandshake(Some(peer1Addr), None)
@@ -124,28 +130,36 @@ class NetworkControllerSpec extends NetworkTests {
 
     val peer2Addr = new InetSocketAddress("88.77.66.56", 5678)
     val testPeer2 = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
+
+    peerManager ! AddOrUpdatePeer(getPeerInfo(peer2Addr), Some(source))
+
     testPeer2.connectAndExpectSuccessfulMessages(peer2Addr, nodeAddr, Tcp.ResumeReading)
     testPeer2.receiveHandshake
     testPeer2.sendHandshake(Some(peer2Addr), None)
 
-    testPeer1.sendGetPeers
+    testPeer1.sendGetPeers()
     testPeer1.receivePeers.flatMap(_.declaredAddress) should contain theSameElementsAs Seq(peer1Addr, peer2Addr)
 
     system.terminate()
   }
 
   it should "send known local peers" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
 
     val nodeAddr = new InetSocketAddress("88.77.66.55", 12345)
     val settings2 = settings.copy(network = settings.network.copy(bindAddress = nodeAddr))
-    val (networkControllerRef: ActorRef, _) = createNetworkController(settings2, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, peerManagerRef) = createNetworkController(settings2, tcpManagerProbe)
 
     val testPeer1 = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
     val peer1DecalredAddr = new InetSocketAddress("88.77.66.55", 5678)
     val peer1LocalAddr = new InetSocketAddress("192.168.1.55", 5678)
+
+    val sourcePeer = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+
+    peerManagerRef ! AddOrUpdatePeer(getPeerInfo(peer1DecalredAddr), Some(sourcePeer))
+
     testPeer1.connectAndExpectSuccessfulMessages(peer1LocalAddr, nodeAddr, Tcp.ResumeReading)
     testPeer1.receiveHandshake
     testPeer1.sendHandshake(Some(peer1DecalredAddr), Some(peer1LocalAddr))
@@ -155,18 +169,21 @@ class NetworkControllerSpec extends NetworkTests {
     val peer2DeclaredAddr = new InetSocketAddress("88.77.66.56", 5678)
     val peer2LocalAddr = new InetSocketAddress("192.168.1.56", 5678)
     val testPeer2 = new TestPeer(settings2, networkControllerRef, tcpManagerProbe)
+
+    peerManagerRef ! AddOrUpdatePeer(getPeerInfo(peer2DeclaredAddr), Some(sourcePeer))
+
     testPeer2.connectAndExpectSuccessfulMessages(peer2LocalAddr, nodeAddr, Tcp.ResumeReading)
     testPeer2.receiveHandshake
     testPeer2.sendHandshake(Some(peer2DeclaredAddr), Some(peer2LocalAddr))
 
-    testPeer1.sendGetPeers
-    testPeer1.receivePeers.flatMap(_.localAddressOpt) should contain theSameElementsAs Seq(peer1LocalAddr, peer2LocalAddr)
+    testPeer1.sendGetPeers()
+    testPeer1.receivePeers.flatMap(_.address) should contain theSameElementsAs Seq(peer1DecalredAddr, peer2DeclaredAddr)
 
     system.terminate()
   }
 
   it should "send close message when maxIncomingConnections threshold is reached" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
 
@@ -191,7 +208,7 @@ class NetworkControllerSpec extends NetworkTests {
   }
 
   it should "send close message when maxOutgoingConnections threshold is reached" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
 
@@ -219,7 +236,7 @@ class NetworkControllerSpec extends NetworkTests {
   }
 
   it should "not send known local address of peer when node is not in local network" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
 
@@ -242,22 +259,27 @@ class NetworkControllerSpec extends NetworkTests {
     testPeer2.receiveHandshake
     testPeer2.sendHandshake(Some(peer2DeclaredAddr), None)
 
-    testPeer2.sendGetPeers
+    testPeer2.sendGetPeers()
     testPeer2.receivePeers should not contain peer1LocalAddr
 
     system.terminate()
   }
 
   it should "not connect to itself" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val tcpManagerProbe = TestProbe()
 
     val nodeAddr = new InetSocketAddress("127.0.0.1", settings.network.bindAddress.getPort)
-    val (networkControllerRef: ActorRef, _) = createNetworkController(settings, tcpManagerProbe)
+    val (networkControllerRef: ActorRef, peerManager: ActorRef) = createNetworkController(settings, tcpManagerProbe)
     val testPeer = new TestPeer(settings, networkControllerRef, tcpManagerProbe)
 
     val peerLocalAddress = new InetSocketAddress("192.168.1.2", settings.network.bindAddress.getPort)
+
+    val sourcePeer = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+
+    // Act
+    peerManager ! AddOrUpdatePeer(getPeerInfo(peerLocalAddress), Some(sourcePeer))
 
     testPeer.connectAndExpectSuccessfulMessages(new InetSocketAddress("192.168.1.2", 5678), nodeAddr, Tcp.ResumeReading)
 
@@ -266,7 +288,7 @@ class NetworkControllerSpec extends NetworkTests {
     testPeer.sendHandshake(None, Some(peerLocalAddress))
     testPeer.sendPeers(Seq(getPeerInfo(nodeLocalAddress).peerSpec))
 
-    testPeer.sendGetPeers
+    testPeer.sendGetPeers()
     val peers = testPeer.receivePeers
 
     peers.flatMap(_.address) should contain theSameElementsAs Seq(peerLocalAddress)
@@ -274,7 +296,7 @@ class NetworkControllerSpec extends NetworkTests {
   }
 
   it should "update last-seen on getting message from peer" in {
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
     val tcpManagerProbe = TestProbe()
     val p = TestProbe("p")(system)
 
@@ -346,8 +368,10 @@ class NetworkControllerSpec extends NetworkTests {
     val activeConnections = Map.empty[InetSocketAddress, ConnectedPeer]
     val unconfirmedConnections = Set.empty[InetSocketAddress]
 
+    val sourcePeer = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+
     // Act
-    peerManager ! AddOrUpdatePeer(peerInfoOne)
+    peerManager ! AddOrUpdatePeer(peerInfoOne, Some(sourcePeer))
     networkControllerRef ! ConnectionToPeer(activeConnections, unconfirmedConnections)
 
     // Assert
@@ -410,10 +434,11 @@ class NetworkControllerSpec extends NetworkTests {
       1,
       Some(peerInfoOne)
     )
+    val sourcePeer = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
 
     // Act
-    peerManagerRef ! AddOrUpdatePeer(peerInfoOne)
-    peerManagerRef ! AddOrUpdatePeer(peerInfoTwo)
+    peerManagerRef ! AddOrUpdatePeer(peerInfoOne, Some(sourcePeer))
+    peerManagerRef ! AddOrUpdatePeer(peerInfoTwo, Some(sourcePeer))
     networkControllerRef ! ConnectionToPeer(activeConnections, unconfirmedConnections)
 
     // Assert
@@ -447,10 +472,11 @@ class NetworkControllerSpec extends NetworkTests {
       1,
       Some(peerInfoOne)
     )
+    val sourcePeer = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
 
     // Act
-    peerManagerRef ! AddOrUpdatePeer(peerInfoOne)
-    peerManagerRef ! AddOrUpdatePeer(peerInfoTwo)
+    peerManagerRef ! AddOrUpdatePeer(peerInfoOne, Some(sourcePeer))
+    peerManagerRef ! AddOrUpdatePeer(peerInfoTwo, Some(sourcePeer))
     networkControllerRef ! ConnectionToPeer(activeConnections, unconfirmedConnections)
 
     // Assert
@@ -477,7 +503,14 @@ class NetworkControllerSpec extends NetworkTests {
     val messageSpecs = Seq(GetPeersSpec, peersSpec)
     val sparkzContext = SparkzContext(messageSpecs, Seq.empty, timeProvider, externalAddr)
 
-    val peerManagerRef = PeerManagerRef(settings, sparkzContext)
+    val nKey = 1234
+    val bucketConfig: BucketConfig = BucketConfig(buckets = 10, bucketPositions = 10, bucketSubgroups = 10)
+    val triedBucket: TriedPeerBucketStorage = TriedPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val newBucket: NewPeerBucketStorage = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val bucketManager: BucketManager = new BucketManager(newBucket, triedBucket)
+
+    val peerDatabase = new InMemoryPeerDatabase(settings.network, sparkzContext.timeProvider, bucketManager, mutable.Map.empty, mutable.Map.empty)
+    val peerManagerRef = PeerManagerRef(settings, sparkzContext, peerDatabase)
 
     val networkControllerRef: ActorRef = NetworkControllerRef(
       "networkController", settings.network,
@@ -485,7 +518,6 @@ class NetworkControllerSpec extends NetworkTests {
 
     val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer",
       networkControllerRef, peerManagerRef, settings.network, featureSerializers)
-
 
     tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))
 

--- a/src/test/scala/sparkz/core/network/peer/BucketManagerTest.scala
+++ b/src/test/scala/sparkz/core/network/peer/BucketManagerTest.scala
@@ -1,0 +1,188 @@
+package sparkz.core.network.peer
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar.{doReturn, spy}
+import sparkz.core.network.peer.BucketManager.Exception.PeerNotFoundException
+import sparkz.core.network.peer.BucketManager.PeerBucketValue
+import sparkz.core.network.peer.PeerBucketStorage.{BucketConfig, NewPeerBucketStorage, TriedPeerBucketStorage}
+import sparkz.core.network.{ConnectedPeer, ConnectionId, Incoming, NetworkTests}
+
+import java.net.InetSocketAddress
+
+class BucketManagerTest extends NetworkTests {
+  private val bucketConf = BucketConfig(256, 64, 8)
+  private val nKey = 1234
+  private val newBucket = NewPeerBucketStorage(bucketConf, nKey, timeProvider)
+  private val triedBucket = TriedPeerBucketStorage(bucketConf, nKey, timeProvider)
+
+  "BucketManager" should "be empty when created" in {
+    // Arrange
+    val bucketManager = new BucketManager(newBucket, triedBucket)
+
+    // Assert
+    bucketManager.isEmpty shouldBe true
+    bucketManager.getTriedPeers shouldBe Map.empty
+  }
+
+  it should "persist a new peer added and being able to retrieve it" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo = getPeerInfo(peerAddress)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val peerBucketValue = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+    val bucketManager = new BucketManager(newBucket, triedBucket)
+
+    // Act
+    bucketManager.addNewPeer(peerBucketValue)
+
+    // Assert
+    bucketManager.isEmpty shouldBe false
+
+    val retrievedPeer = bucketManager.getPeer(peerAddress)
+    retrievedPeer match {
+      case Some(storedPeer) => peerBucketValue shouldBe storedPeer
+      case _ => fail("")
+    }
+
+    system.terminate()
+  }
+
+  it should "move the peer when established a connection to it" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo = getPeerInfo(peerAddress)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val peerBucketValue = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+    val bucketManager = new BucketManager(newBucket, triedBucket)
+    bucketManager.addNewPeer(peerBucketValue)
+
+    // Act
+    bucketManager.makeTried(peerAddress)
+
+    // Assert
+    bucketManager.isEmpty shouldBe false
+
+    val retrievedTriedPeer = bucketManager.getTriedPeers(peerAddress)
+    retrievedTriedPeer shouldBe peerInfo
+    val retrievedNewPeer = bucketManager.getNewPeers
+    retrievedNewPeer.isEmpty shouldBe true
+
+    system.terminate()
+  }
+
+  it should "re-add a peer's address into new" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo = getPeerInfo(peerAddress)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val peerBucketValue = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+    val bucketManager = new BucketManager(newBucket, triedBucket)
+    bucketManager.addNewPeer(peerBucketValue)
+    bucketManager.makeTried(peerAddress)
+
+    // Act
+    bucketManager.addNewPeer(peerBucketValue)
+
+    // Assert
+    bucketManager.isEmpty shouldBe false
+
+    val triedPeers = bucketManager.getTriedPeers
+    val newPeers = bucketManager.getNewPeers
+    triedPeers.size shouldBe 1
+    newPeers.size shouldBe 1
+    triedPeers.contains(peerAddress) shouldBe true
+    newPeers.contains(peerAddress) shouldBe true
+
+    system.terminate()
+  }
+
+  it should "remove all occurrences of the same peer's address" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo = getPeerInfo(peerAddress)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val peerBucketValue = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+    val bucketManager = new BucketManager(newBucket, triedBucket)
+    bucketManager.addNewPeer(peerBucketValue)
+    bucketManager.makeTried(peerAddress)
+    bucketManager.addNewPeer(peerBucketValue)
+
+    // Act
+    bucketManager.removePeer(peerAddress)
+
+    // Assert
+    bucketManager.isEmpty shouldBe true
+
+    system.terminate()
+  }
+
+  it should "raise a PeerNotFoundException if makeTried method is called but the peer does not exist in the new table" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val bucketManager = new BucketManager(newBucket, triedBucket)
+
+    // Act
+    val exception = intercept[PeerNotFoundException] {
+      bucketManager.makeTried(peerAddress)
+    }
+
+    // Assert
+    exception.getMessage shouldBe s"Cannot move peer $peerAddress to tried table because it doesn't exist in new"
+
+    system.terminate()
+  }
+
+  it should "correctly move peers from tried back to new without deleting them" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val bucket = 1
+    val bucketPosition = 1
+    val bucketConfig = BucketConfig(10, 10, 10)
+    val newBucketMock = spy(NewPeerBucketStorage(bucketConfig, nKey, timeProvider))
+    val triedBucketMock = spy(TriedPeerBucketStorage(bucketConfig, nKey, timeProvider))
+
+    doReturn(bucket).when(triedBucketMock).getBucket(any())
+    doReturn(bucketPosition).when(triedBucketMock).getBucketPosition(any(), any())
+
+    val peerAddress1 = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo1 = getPeerInfo(peerAddress1)
+    val sourcePeer = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val peer1 = PeerBucketValue(peerInfo1, sourcePeer.toSourcePeer, isNew = true)
+
+    val peerAddress2 = new InetSocketAddress("88.77.66.55", 1234)
+    val peerInfo2 = getPeerInfo(peerAddress2)
+    val peer2 = PeerBucketValue(peerInfo2, sourcePeer.toSourcePeer, isNew = true)
+
+    val bucketManager = new BucketManager(newBucketMock, triedBucketMock)
+
+    // Act
+    bucketManager.addNewPeer(peer1)
+    bucketManager.addNewPeer(peer2)
+    bucketManager.makeTried(peerAddress1)
+    bucketManager.makeTried(peerAddress2)
+
+    // Assert
+    bucketManager.isEmpty shouldBe false
+
+    val newPeers = bucketManager.getNewPeers
+    val triedPeers = bucketManager.getTriedPeers
+
+    newPeers shouldBe Map(peerAddress1 -> peerInfo1)
+    triedPeers shouldBe Map(peerAddress2 -> peerInfo2)
+
+    system.terminate()
+  }
+}

--- a/src/test/scala/sparkz/core/network/peer/InMemoryPeerDatabaseSpec.scala
+++ b/src/test/scala/sparkz/core/network/peer/InMemoryPeerDatabaseSpec.scala
@@ -1,37 +1,53 @@
 package sparkz.core.network.peer
 
-import java.net.InetSocketAddress
 import org.scalatest.Assertion
-import sparkz.core.network.Outgoing
+import sparkz.ObjectGenerators
 import sparkz.core.network.NetworkTests
+import sparkz.core.network.peer.PeerBucketStorage.{BucketConfig, NewPeerBucketStorage, TriedPeerBucketStorage}
 
+import java.net.InetSocketAddress
+import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
-import scala.util.Random
 
-class InMemoryPeerDatabaseSpec extends NetworkTests {
+@SuppressWarnings(Array(
+  "org.wartremover.warts.Null",
+  "org.wartremover.warts.OptionPartial"
+))
+class InMemoryPeerDatabaseSpec extends NetworkTests with ObjectGenerators {
 
   private val peerAddress1 = new InetSocketAddress("1.1.1.1", 27017)
   private val peerAddress2 = new InetSocketAddress("2.2.2.2", 27017)
   private val storedPeersLimit = 10
+  private val nKey = 1234
+  private val bucketConfig: BucketConfig = BucketConfig(buckets = 10, bucketPositions = 10, bucketSubgroups = 10)
+  private val triedBucket: TriedPeerBucketStorage = TriedPeerBucketStorage(bucketConfig, nKey, timeProvider)
+  private val newBucket: NewPeerBucketStorage = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+  private val bucketManager: BucketManager = new BucketManager(newBucket, triedBucket)
+  private val sourcePeer = connectedPeerGen(null).sample.get
 
   private def withDb(test: InMemoryPeerDatabase => Assertion): Assertion =
-    test(new InMemoryPeerDatabase(settings.network.copy(storedPeersLimit = storedPeersLimit, penaltySafeInterval = 1.seconds), timeProvider))
+    test(new InMemoryPeerDatabase(
+      settings.network.copy(storedPeersLimit = storedPeersLimit, penaltySafeInterval = 1.seconds),
+      timeProvider,
+      bucketManager,
+      mutable.Map.empty,
+      mutable.Map.empty))
 
   "new DB" should "be empty" in {
     withDb { db =>
       db.isEmpty shouldBe true
       db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.isEmpty shouldBe true
-      db.knownPeers.isEmpty shouldBe true
+      db.allPeers.isEmpty shouldBe true
+      db.allPeers.isEmpty shouldBe true
     }
   }
 
   it should "be non-empty after adding a peer" in {
     withDb { db =>
-      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress1))
+      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress1), Some(sourcePeer))
       db.isEmpty shouldBe false
       db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.isEmpty shouldBe false
+      db.allPeers.isEmpty shouldBe false
     }
   }
 
@@ -39,26 +55,26 @@ class InMemoryPeerDatabaseSpec extends NetworkTests {
     withDb { db =>
       val peerInfo = getPeerInfo(peerAddress1)
 
-      db.addOrUpdateKnownPeer(peerInfo)
-      db.knownPeers shouldBe Map(peerAddress1 -> peerInfo)
+      db.addOrUpdateKnownPeer(peerInfo, Some(sourcePeer))
+      db.allPeers shouldBe Map(peerAddress1 -> peerInfo)
     }
   }
 
   it should "return an updated peer after updating a peer" in {
     withDb { db =>
       val peerInfo = getPeerInfo(peerAddress1, Some("initialName"))
-      db.addOrUpdateKnownPeer(peerInfo)
+      db.addOrUpdateKnownPeer(peerInfo, Some(sourcePeer))
       val newPeerInfo = getPeerInfo(peerAddress1, Some("updatedName"))
-      db.addOrUpdateKnownPeer(newPeerInfo)
+      db.addOrUpdateKnownPeer(newPeerInfo, Some(sourcePeer))
 
-      db.knownPeers shouldBe Map(peerAddress1 -> newPeerInfo)
+      db.allPeers shouldBe Map(peerAddress1 -> newPeerInfo)
     }
   }
 
   it should "return a blacklisted peer after blacklisting" in {
     withDb { db =>
-      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress1))
-      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress2))
+      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress1), Some(sourcePeer))
+      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress2), Some(sourcePeer))
       db.addToBlacklist(peerAddress1, PenaltyType.PermanentPenalty)
 
       db.isBlacklisted(peerAddress1.getAddress) shouldBe true
@@ -70,20 +86,20 @@ class InMemoryPeerDatabaseSpec extends NetworkTests {
   it should "the blacklisted peer be absent in knownPeers" in {
     withDb { db =>
       val peerInfo1 = getPeerInfo(peerAddress1)
-      db.addOrUpdateKnownPeer(peerInfo1)
-      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress2))
+      db.addOrUpdateKnownPeer(peerInfo1, Some(sourcePeer))
+      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress2), Some(sourcePeer))
       db.addToBlacklist(peerAddress2, PenaltyType.PermanentPenalty)
 
-      db.knownPeers shouldBe Map(peerAddress1 -> peerInfo1)
+      db.allPeers shouldBe Map(peerAddress1 -> peerInfo1)
     }
   }
 
   it should "remove peers from db correctly" in {
     withDb { db =>
-      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress1))
+      db.addOrUpdateKnownPeer(getPeerInfo(peerAddress1), Some(sourcePeer))
       db.isEmpty shouldBe false
       db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.isEmpty shouldBe false
+      db.allPeers.isEmpty shouldBe false
 
       db.remove(peerAddress1)
 
@@ -104,92 +120,6 @@ class InMemoryPeerDatabaseSpec extends NetworkTests {
       db.penaltyScore(peerAddress1) shouldBe PenaltyType.SpamPenalty.penaltyScore
       db.peerPenaltyScoreOverThreshold(peerAddress1, PenaltyType.MisbehaviorPenalty)
       db.penaltyScore(peerAddress1) shouldBe PenaltyType.SpamPenalty.penaltyScore
-    }
-  }
-
-  it should "not add more peers than configured by storedPeersLimit" in {
-    withDb { db =>
-
-      val ninePeers = generatePeers(9)
-      val oneMorePeer = generatePeers(1)
-      val fiveMorePeers = generatePeers(5)
-      db.addOrUpdateKnownPeers(ninePeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe 9
-
-      db.addOrUpdateKnownPeers(oneMorePeer)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe storedPeersLimit
-
-      db.addOrUpdateKnownPeers(fiveMorePeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe storedPeersLimit
-    }
-  }
-
-  it should "not replace existing peers if they are connected" in {
-    withDb { db =>
-      val peersLimit = storedPeersLimit
-      val nineConnectedPeers = generatePeers(peersLimit - 1).map(_.copy(connectionType = Some(Outgoing)))
-      val fiveMorePeers = generatePeers(5)
-      db.addOrUpdateKnownPeers(nineConnectedPeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe 9
-
-      db.addOrUpdateKnownPeers(fiveMorePeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.values should (contain allElementsOf nineConnectedPeers and have size storedPeersLimit)
-    }
-  }
-
-  it should "should replace oldest not-connected peers" in {
-    withDb { db =>
-      val tenPeersLimit = storedPeersLimit
-
-      val oldestFivePeers = generatePeers(5)
-      val medianFivePeers = generatePeers(5)
-      val newestFivePeers = generatePeers(5)
-
-      db.addOrUpdateKnownPeers(oldestFivePeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.values should (have size 5 and contain allElementsOf oldestFivePeers)
-
-      db.addOrUpdateKnownPeers(medianFivePeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe tenPeersLimit
-      db.knownPeers.values should (contain allElementsOf oldestFivePeers and contain allElementsOf medianFivePeers)
-
-      db.addOrUpdateKnownPeers(newestFivePeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe tenPeersLimit
-      db.knownPeers.values should (contain allElementsOf medianFivePeers and contain allElementsOf newestFivePeers)
-    }
-  }
-
-  it should "replace not-connected peers even if they are latest" in {
-    withDb { db =>
-      val tenPeersLimit = storedPeersLimit
-      val twoPeers = 2
-      val eightPeers = tenPeersLimit - 2
-
-      val eightConnectedPeers = generatePeers(eightPeers).map(_.copy(connectionType = Some(Outgoing)))
-      val twoNotConnected = generatePeers(twoPeers)
-      val twoMoreNotConnected = generatePeers(twoPeers)
-
-      db.addOrUpdateKnownPeers(eightConnectedPeers)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe eightPeers
-
-      db.addOrUpdateKnownPeers(twoNotConnected)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe tenPeersLimit
-      db.knownPeers.values should (contain allElementsOf eightConnectedPeers and contain allElementsOf twoNotConnected)
-
-
-      db.addOrUpdateKnownPeers(twoMoreNotConnected)
-      db.blacklistedPeers.isEmpty shouldBe true
-      db.knownPeers.size shouldBe tenPeersLimit
-      db.knownPeers.values should (contain allElementsOf eightConnectedPeers and contain allElementsOf twoMoreNotConnected)
     }
   }
 
@@ -227,19 +157,6 @@ class InMemoryPeerDatabaseSpec extends NetworkTests {
       val penalizeWithBan = db.peerPenaltyScoreOverThreshold(address, penaltyType)
 
       penalizeWithBan shouldBe true
-    }
-  }
-
-  private def generatePeers(amount: Int) = {
-    val random = Random
-    val base = (1 to 3).map(_ => random.nextInt(256)).mkString(".")
-    var counter = 1
-    (1 to amount).map { _ =>
-      val host = base + counter
-      counter += 1
-      getPeerInfo(
-        new InetSocketAddress(host, 0)
-      )
     }
   }
 

--- a/src/test/scala/sparkz/core/network/peer/PeerBucketStorageTest.scala
+++ b/src/test/scala/sparkz/core/network/peer/PeerBucketStorageTest.scala
@@ -1,0 +1,149 @@
+package sparkz.core.network.peer
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import sparkz.core.network.peer.BucketManager.PeerBucketValue
+import sparkz.core.network.peer.PeerBucketStorage.{BucketConfig, NewPeerBucketStorage, TriedPeerBucketStorage}
+import sparkz.core.network.{ConnectedPeer, ConnectionId, Incoming, NetworkTests}
+
+import java.net.InetSocketAddress
+
+class PeerBucketStorageTest extends NetworkTests {
+  private val buckets = 256
+  private val bucketPositions = 64
+  private val bucketSubgroups = 8
+  private val nKey = 1234
+
+  "Both new and tried buckets" should "should be empty when created" in {
+    // Arrange
+    val bucketConfig = BucketConfig(buckets, bucketPositions, bucketSubgroups)
+    val tried = TriedPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val newB = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+
+    // Assert
+    tried.isEmpty shouldBe true
+    newB.isEmpty shouldBe true
+
+    tried.getPeers shouldBe Map.empty
+    newB.getPeers shouldBe Map.empty
+  }
+
+  they should "persist the peer when one is added" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val bucketConfig = BucketConfig(buckets, bucketPositions, bucketSubgroups)
+    val tried = TriedPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val newB = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo = getPeerInfo(peerAddress)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val newPeer = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+    val triedPeer = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = false)
+
+    // Act
+    newB.add(newPeer)
+    tried.add(triedPeer)
+
+    // Assert
+    newB.isEmpty shouldBe false
+    tried.isEmpty shouldBe false
+
+    val newPeers = newB.getPeers
+    val triedPeers = tried.getPeers
+    newPeer.peerInfo.peerSpec.address match {
+      case Some(address) => newPeers.contains(address) shouldBe true
+      case _ => fail("Expected newPeer to have a valid address")
+    }
+    triedPeer.peerInfo.peerSpec.address match {
+      case Some(address) => triedPeers.contains(address) shouldBe true
+      case _ => fail("Expected newPeer to have a valid address")
+    }
+
+    system.terminate()
+  }
+
+  they should "delete existing peers" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val bucketConfig = BucketConfig(buckets, bucketPositions, bucketSubgroups)
+    val tried = TriedPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val newB = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo = getPeerInfo(peerAddress)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val newPeer = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+    val triedPeer = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = false)
+    newB.add(newPeer)
+    tried.add(triedPeer)
+
+    // Act
+    newPeer.peerInfo.peerSpec.address.foreach(address => newB.remove(address))
+    triedPeer.peerInfo.peerSpec.address.foreach(address => tried.remove(address))
+
+    // Assert
+    newB.isEmpty shouldBe true
+    tried.isEmpty shouldBe true
+
+    newB.getPeers shouldBe Map.empty
+    tried.getPeers shouldBe Map.empty
+
+    system.terminate()
+  }
+
+  they should "do nothing when removing a non existing peer" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val bucketConfig = BucketConfig(buckets, bucketPositions, bucketSubgroups)
+    val tried = TriedPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val newB = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val peerAddress = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo = getPeerInfo(peerAddress)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val newPeer = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+    val triedPeer = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = false)
+
+    // Act
+    newPeer.peerInfo.peerSpec.address.foreach(address => newB.remove(address))
+    triedPeer.peerInfo.peerSpec.address.foreach(address => tried.remove(address))
+
+    // Assert
+    newB.isEmpty shouldBe true
+    tried.isEmpty shouldBe true
+
+    newB.getPeers shouldBe Map.empty
+    tried.getPeers shouldBe Map.empty
+
+    system.terminate()
+  }
+
+  they should "return properly when contains method is called" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val bucketConfig = BucketConfig(buckets, bucketPositions, bucketSubgroups)
+    val newB = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+    val peerAddress1 = new InetSocketAddress("55.66.77.88", 1234)
+    val peerInfo1 = getPeerInfo(peerAddress1)
+    val peerAddress2 = new InetSocketAddress("88.77.66.55", 1234)
+    val peerInfo2 = getPeerInfo(peerAddress2)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    val newPeer1 = PeerBucketValue(peerInfo1, source.toSourcePeer, isNew = true)
+    val newPeer2 = PeerBucketValue(peerInfo2, source.toSourcePeer, isNew = true)
+    val fakeAddress = new InetSocketAddress("55.88.77.66", 1234)
+
+    // Act
+    newB.add(newPeer1)
+    newB.add(newPeer2)
+
+    // Assert
+    newB.isEmpty shouldBe false
+    newB.contains(peerAddress1) shouldBe true
+    newB.contains(peerAddress2) shouldBe true
+    newB.contains(fakeAddress) shouldBe false
+
+    system.terminate()
+  }
+}

--- a/src/test/scala/sparkz/core/storage/ScheduledStorageFileWriterTest.scala
+++ b/src/test/scala/sparkz/core/storage/ScheduledStorageFileWriterTest.scala
@@ -1,0 +1,136 @@
+package sparkz.core.storage
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import org.mockito.MockitoSugar.mock
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import sparkz.core.network.peer.BucketManager.PeerBucketValue
+import sparkz.core.network.peer.PeerBucketStorage.{BucketConfig, NewPeerBucketStorage}
+import sparkz.core.network.{ConnectedPeer, ConnectionId, Incoming, NetworkTests}
+import sparkz.core.storage.ScheduledActor.ScheduledActorConfig
+import sparkz.core.storage.ScheduledStorageFilePersister.ScheduledStorageFilePersisterConfig
+import sparkz.core.storage.ScheduledStoragePersister.ScheduledStoragePersisterConfig
+import sparkz.core.storage.StoragePersisterContainer.StoragePersisterContainerConfig
+import sparkz.core.utils.TimeProvider
+
+import java.io.File
+import java.net.{InetAddress, InetSocketAddress}
+import java.nio.file.{Files, Path}
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.util.Random
+
+class ScheduledStorageFileWriterTest extends NetworkTests with BeforeAndAfterAll with BeforeAndAfterEach {
+  private val tempDir = Files.createTempDirectory("temp-directory")
+  private var tempFile: Option[Path] = None
+  private val random = new Random()
+  private val MAX_ELEMENTS_TO_INSERT = 10000
+
+  override protected def afterAll(): Unit = {
+    tempDir.toFile.deleteOnExit()
+  }
+
+  override protected def beforeEach(): Unit = {
+    tempFile = Some(Files.createTempFile(tempDir, "tempFile", ""))
+  }
+
+  override protected def afterEach(): Unit = {
+    tempFile.foreach(path => Files.deleteIfExists(path))
+  }
+
+  private implicit val executionContext: ExecutionContext = mock[ExecutionContext]
+
+  "The ScheduledPeerBucketWriter" should "persist and restore the peers in a bucket" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val nKey = 1234
+
+    val bucketConfig = BucketConfig(1024, 512, 64)
+    val newB = NewPeerBucketStorage(bucketConfig, nKey, timeProvider)
+
+    val writerConfig = tempFile match {
+      case Some(file) =>
+        val scheduledStorageWriterConfig = ScheduledStoragePersisterConfig(
+          ScheduledActorConfig(1.minutes, 10.minutes)
+        )
+        ScheduledStorageFilePersisterConfig(tempDir.toFile, file.getFileName.toString, scheduledStorageWriterConfig)
+      case None => fail("")
+    }
+
+    val storageWriter = new ScheduledPeerBucketPersister(newB, writerConfig)
+    val source = ConnectedPeer(ConnectionId(new InetSocketAddress(10), new InetSocketAddress(11), Incoming), TestProbe().ref, 0L, None)
+    for (_ <- 1 to MAX_ELEMENTS_TO_INSERT) {
+      val peerAddress = new InetSocketAddress(s"${random.nextInt(255)}.${random.nextInt(255)}.${random.nextInt(255)}.${random.nextInt(255)}", random.nextInt(35000))
+      val peerInfo = getPeerInfo(peerAddress)
+      val peer = PeerBucketValue(peerInfo, source.toSourcePeer, isNew = true)
+      newB.add(peer)
+    }
+    val expectedPeersSize = newB.getPeers.size
+    expectedPeersSize should be > 0
+
+    // Act
+    storageWriter.persist()
+    newB.clear()
+
+    val peersSizeAfterCleaning = newB.getPeers.size
+    peersSizeAfterCleaning shouldBe 0
+
+    storageWriter.restore()
+
+    // Assert
+    newB.getPeers.size shouldBe expectedPeersSize
+
+    system.terminate()
+  }
+
+  "The ScheduledMapWriter" should "persist and restore the peers in a map" in {
+    // Arrange
+    implicit val system: ActorSystem = ActorSystem()
+
+    val blacklist = mutable.Map.empty[InetAddress, TimeProvider.Time]
+    val penaltyBook = mutable.Map.empty[InetAddress, (Int, Long)]
+    val config = tempFile match {
+      case Some(file) =>
+        val scheduledStorageWriterConfig = ScheduledStoragePersisterConfig(
+          ScheduledActorConfig(1.minutes, 10.minutes)
+        )
+        ScheduledStorageFilePersisterConfig(tempDir.toFile, file.getFileName.toString, scheduledStorageWriterConfig)
+      case None => fail("")
+    }
+
+    val blacklistWriter = new ScheduledMapPersister(blacklist, config)
+    val penaltyWriter = new ScheduledMapPersister(penaltyBook, config)
+
+    for (_ <- 1 to MAX_ELEMENTS_TO_INSERT) {
+      val peerAddress = new InetSocketAddress(s"${random.nextInt(255)}.${random.nextInt(255)}.${random.nextInt(255)}.${random.nextInt(255)}", random.nextInt(35000)).getAddress
+      blacklist += peerAddress -> timeProvider.time()
+      penaltyBook += peerAddress -> (random.nextInt(), random.nextLong())
+    }
+    val expectedBlacklistedSize = blacklist.size
+    expectedBlacklistedSize shouldBe MAX_ELEMENTS_TO_INSERT
+
+    val expectedPenaltyBookSize = blacklist.size
+    expectedPenaltyBookSize shouldBe MAX_ELEMENTS_TO_INSERT
+
+    // Act
+    blacklistWriter.persist()
+    penaltyWriter.persist()
+
+    blacklist.clear()
+    penaltyBook.clear()
+
+    blacklist.size shouldBe 0
+    penaltyBook.size shouldBe 0
+
+    blacklistWriter.restore()
+    penaltyWriter.restore()
+
+    // Assert
+    blacklist.size shouldBe MAX_ELEMENTS_TO_INSERT
+    penaltyBook.size shouldBe MAX_ELEMENTS_TO_INSERT
+
+    system.terminate()
+  }
+}


### PR DESCRIPTION
This PR contains also branch 485 to include the new peer storage feature.
Here is the [document](https://www.notion.so/horizen-labs/Investigation-Scorex-how-to-persist-node-s-peers-to-disk-2232e9d1f18d43458798bddbace57479) with the different persistence solution suggested and the picked one.
This PR is adding a scheduled job that every N minutes (this parameter is set in the config file) writes to disk all peer's data structures (new, tried, and blacklisted). When the node is started, it tries to back-up peers from the saved files, if any.