### PR TITLE
Sparkz rc10 snapshot fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ val networkDependencies = Seq(
   "com.typesafe.akka" %% "akka-parsing" % akkaHttpVersion,
   "com.typesafe.akka" %% "akka-protobuf" % akkaVersion,
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "commons-net" % "commons-net" % "3.8.0"
+  "commons-net" % "commons-net" % "3.9.0"
 )
 
 val apiDependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val commonSettings = Seq(
     Wart.OptionPartial),
   organization := "io.horizen",
   organizationName := "Zen Blockchain Foundation",
-  version := "2.0.0-RC10-SNAPSHOT",
+  version := "2.0.0-RC10-SNAPSHOT2",
   licenses := Seq("CC0" -> url("https://creativecommons.org/publicdomain/zero/1.0/legalcode")),
   homepage := Some(url("https://github.com/HorizenOfficial/Sparkz")),
   pomExtra :=

--- a/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
@@ -11,6 +11,7 @@ import sparkz.core.utils.{NetworkUtils, TimeProvider}
 import sparkz.util.SparkzLogging
 
 import java.net.{InetAddress, InetSocketAddress}
+import java.nio.file.Paths
 import java.security.SecureRandom
 import scala.collection.mutable
 import scala.concurrent.duration._
@@ -177,12 +178,13 @@ final class InMemoryPeerDatabase(sparkzSettings: SparkzSettings, sparkzContext: 
     }
   }
 
-  override def storagesToBackup(): Seq[StorageBackupper[_]] = {
+  override def storagesToBackup(pathToBackup: String): Seq[StorageBackupper[_]] = {
+    val path = Paths.get(pathToBackup)
     Seq(
-      new PeerBucketBackupper[PeerBucketStorageImpl](newBucket, StorageFileBackupperConfig(sparkzSettings.dataDir, "NewBucket.dat")),
-      new PeerBucketBackupper[PeerBucketStorageImpl](triedBucket, StorageFileBackupperConfig(sparkzSettings.dataDir, "TriedBucket.dat")),
-      new MapBackupper(blacklist, StorageFileBackupperConfig(sparkzSettings.dataDir, "BlacklistPeers.dat")),
-      new MapBackupper(penaltyBook, StorageFileBackupperConfig(sparkzSettings.dataDir, "PenaltyBook.dat"))
+      new PeerBucketBackupper[PeerBucketStorageImpl](newBucket, StorageFileBackupperConfig(path.toFile, "NewBucket.dat")),
+      new PeerBucketBackupper[PeerBucketStorageImpl](triedBucket, StorageFileBackupperConfig(path.toFile, "TriedBucket.dat")),
+      new MapBackupper(blacklist, StorageFileBackupperConfig(path.toFile, "BlacklistPeers.dat")),
+      new MapBackupper(penaltyBook, StorageFileBackupperConfig(path.toFile, "PenaltyBook.dat"))
     )
   }
 }

--- a/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
@@ -179,12 +179,12 @@ final class InMemoryPeerDatabase(sparkzSettings: SparkzSettings, sparkzContext: 
   }
 
   override def storagesToBackup(pathToBackup: String): Seq[StorageBackupper[_]] = {
-    val path = Paths.get(pathToBackup)
+    val file = Paths.get(pathToBackup).toFile
     Seq(
-      new PeerBucketBackupper[PeerBucketStorageImpl](newBucket, StorageFileBackupperConfig(path.toFile, "NewBucket.dat")),
-      new PeerBucketBackupper[PeerBucketStorageImpl](triedBucket, StorageFileBackupperConfig(path.toFile, "TriedBucket.dat")),
-      new MapBackupper(blacklist, StorageFileBackupperConfig(path.toFile, "BlacklistPeers.dat")),
-      new MapBackupper(penaltyBook, StorageFileBackupperConfig(path.toFile, "PenaltyBook.dat"))
+      new PeerBucketBackupper[PeerBucketStorageImpl](newBucket, StorageFileBackupperConfig(file, "NewBucket.dat")),
+      new PeerBucketBackupper[PeerBucketStorageImpl](triedBucket, StorageFileBackupperConfig(file, "TriedBucket.dat")),
+      new MapBackupper(blacklist, StorageFileBackupperConfig(file, "BlacklistPeers.dat")),
+      new MapBackupper(penaltyBook, StorageFileBackupperConfig(file, "PenaltyBook.dat"))
     )
   }
 }

--- a/src/main/scala/sparkz/core/persistence/BackupAndRestoreFromFileStrategy.scala
+++ b/src/main/scala/sparkz/core/persistence/BackupAndRestoreFromFileStrategy.scala
@@ -1,27 +1,32 @@
 package sparkz.core.persistence
 
-import sparkz.core.persistence.BackupAndBackupAndRestoreFromFileStrategy.FileBackupStrategyConfig
+import sparkz.core.persistence.BackupAndRestoreFromFileStrategy.FileBackupStrategyConfig
 import sparkz.core.persistence.ScheduledActor.ScheduledActorConfig
 
+import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /**
   * Concrete implementation of backup and restore trait that uses file as storage
-  * @param config The configuration need by the strategy
+  *
+  * @param config           The configuration need by the strategy
   * @param storagesToBackUp The list of storages that will be backedup and restored
-  * @param ec The execution context
+  * @param ec               The execution context
   */
-class BackupAndBackupAndRestoreFromFileStrategy(
-                                                 config: FileBackupStrategyConfig,
-                                                 storagesToBackUp: Seq[StorageBackupper[_]])(implicit ec: ExecutionContext)
+class BackupAndRestoreFromFileStrategy(
+                                        config: FileBackupStrategyConfig,
+                                        storagesToBackUp: Seq[StorageBackupper[_]])(implicit ec: ExecutionContext)
   extends BackupAndRestoreStrategy {
 
   private var scheduledBackupperSeq: Seq[ScheduledStorageBackupper] = Seq()
 
   initBackup()
 
-  private def initBackup(): Unit = backup()
+  private def initBackup(): Unit = {
+    Files.createDirectories(config.directoryPath)
+    backup()
+  }
 
   private def initAllScheduledStorageBackupper: Seq[ScheduledStorageBackupper] = {
     storagesToBackUp.map {
@@ -40,6 +45,10 @@ class BackupAndBackupAndRestoreFromFileStrategy(
   }
 }
 
-object BackupAndBackupAndRestoreFromFileStrategy {
-  case class FileBackupStrategyConfig(storageBackupDelay: FiniteDuration, storageBackupInterval: FiniteDuration)
+object BackupAndRestoreFromFileStrategy {
+  case class FileBackupStrategyConfig(
+                                       directoryPath: Path,
+                                       storageBackupDelay: FiniteDuration,
+                                       storageBackupInterval: FiniteDuration
+                                     )
 }

--- a/src/main/scala/sparkz/core/persistence/PersistablePeerDatabase.scala
+++ b/src/main/scala/sparkz/core/persistence/PersistablePeerDatabase.scala
@@ -3,6 +3,6 @@ package sparkz.core.persistence
 import sparkz.core.network.peer.PeerDatabase
 
 trait PersistablePeerDatabase extends PeerDatabase {
-  def storagesToBackup(): Seq[StorageBackupper[_]]
+  def storagesToBackup(pathToBackup: String): Seq[StorageBackupper[_]]
 }
 

--- a/src/test/scala/sparkz/core/persistence/BackupAndRestoreFromFileStrategyTest.scala
+++ b/src/test/scala/sparkz/core/persistence/BackupAndRestoreFromFileStrategyTest.scala
@@ -2,12 +2,13 @@ package sparkz.core.persistence
 
 import org.mockito.MockitoSugar.{mock, times, verify}
 import org.scalatest.propspec.AnyPropSpec
-import sparkz.core.persistence.BackupAndBackupAndRestoreFromFileStrategy.FileBackupStrategyConfig
+import sparkz.core.persistence.BackupAndRestoreFromFileStrategy.FileBackupStrategyConfig
 
+import java.nio.file.Files
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 
-class BackupAndBackupAndRestoreFromFileStrategyTest extends AnyPropSpec  {
+class BackupAndRestoreFromFileStrategyTest extends AnyPropSpec  {
   property("When the strategy.restore() method is called, each storage restore its content") {
     // Arrange
     implicit val ec: ExecutionContext = mock[ExecutionContext]
@@ -17,9 +18,10 @@ class BackupAndBackupAndRestoreFromFileStrategyTest extends AnyPropSpec  {
     val scheduledStorageBackupper: Seq[StorageBackupper[_]] = Seq(
       firstStorageBackupper, secondStorageBackupper, thirdStorageBackupper
     )
-    val config = FileBackupStrategyConfig(1.minutes, 15.minutes)
+    val tempPath = Files.createTempDirectory("tempDir")
+    val config = FileBackupStrategyConfig(tempPath, 1.minutes, 15.minutes)
 
-    val strategy = new BackupAndBackupAndRestoreFromFileStrategy(
+    val strategy = new BackupAndRestoreFromFileStrategy(
       config,
       scheduledStorageBackupper
     )


### PR DESCRIPTION
-  when the node is started, the node tries to restore the peers from any backup file
- fix the count of connection attempts accounting also for failed attempts
- group peer storages backup files in the same folder