### PR TITLE
Sdk 707 - Remove old property from release-notes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val commonSettings = Seq(
     Wart.OptionPartial),
   organization := "io.horizen",
   organizationName := "Zen Blockchain Foundation",
-  version := "2.0.0-RC10-SNAPSHOT2",
+  version := "2.0.0-RC10-SNAPSHOT",
   licenses := Seq("CC0" -> url("https://creativecommons.org/publicdomain/zero/1.0/legalcode")),
   homepage := Some(url("https://github.com/HorizenOfficial/Sparkz")),
   pomExtra :=

--- a/release-notes.md
+++ b/release-notes.md
@@ -16,8 +16,7 @@
 * configuration changes:
   * maxIncomingConnections & maxOutgoingConnections in place of maxConnections
   * storedPeersLimit: maximum number of PeerSpec objects stored in the in-memory database
-  * requestTrackerDeliveryTimeout: timeout waiting for a response by RequestTracker
-  * penalizeNonDelivery: penalize remote peers not answering our requests during requestTrackerDeliveryTimeout
+  * penalizeNonDelivery: penalize remote peers not answering our requests during deliveryTimeout
   * messageLengthBytesLimit: max message size
   * maxRequestedPerPeer: limit for the number of modifiers to request and process at once
   * maxModifiersSpecMessageSize in place of maxPacketSize: maximum modifier spec message size


### PR DESCRIPTION
`requestTrackerDeliveryTimeout` must be removed since it’s an old property; using `deliveryTimeout` instead
