### PR TITLE
SDK-863: when peer is asking to sync we update our internal status an…

### DIFF
--- a/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
@@ -1,6 +1,5 @@
 package sparkz.core.network
 
-import java.net.InetSocketAddress
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import sparkz.core.NodeViewHolder.ReceivableMessages.{GetNodeViewChanges, ModifiersFromRemote, TransactionsFromRemote}
 import sparkz.core.consensus.History._
@@ -21,11 +20,11 @@ import sparkz.core.{ModifierTypeId, NodeViewModifier, PersistentNodeViewModifier
 import sparkz.util.serialization.{VLQByteBufferReader, VLQReader}
 import sparkz.util.{ModifierId, SparkzEncoding, SparkzLogging}
 
+import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
@@ -193,6 +192,11 @@ class NodeViewSynchronizer[TX <: Transaction, SI <: SyncInfo, SIS <: SyncInfoMes
           log.warn("Extension is empty while comparison is younger")
 
         self ! OtherNodeSyncingStatus(remote, comparison, ext)
+        if (statusTracker.isPeerOutdated(remote)) {
+          // This triggers another round of sync to let the other peer update its internal status about this node
+          networkControllerRef ! SendToNetwork(Message(syncInfoSpec, Right(historyReader.syncInfo), None), SendToPeer(remote))
+        }
+
       case _ =>
     }
   }

--- a/src/main/scala/sparkz/core/network/SyncTracker.scala
+++ b/src/main/scala/sparkz/core/network/SyncTracker.scala
@@ -92,6 +92,8 @@ class SyncTracker(nvsRef: ActorRef,
   private def outdatedPeers(): Seq[ConnectedPeer] =
     lastSyncSentTime.filter(t => (timeProvider.time() - t._2).millis > maxInterval()).keys.toSeq
 
+  def isPeerOutdated(peer: ConnectedPeer): Boolean =
+    (timeProvider.time() - lastSyncSentTime(peer)).millis > maxInterval()
 
   @nowarn def peersByStatus: Map[HistoryComparisonResult, Iterable[ConnectedPeer]] =
     statuses.groupBy(_._2).mapValues(_.keys).toMap

--- a/src/test/scala/sparkz/core/network/TestImplementations.scala
+++ b/src/test/scala/sparkz/core/network/TestImplementations.scala
@@ -2,7 +2,7 @@ package sparkz.core.network
 
 
 import sparkz.core.{ModifierTypeId, PersistentNodeViewModifier}
-import sparkz.core.consensus.History.ModifierIds
+import sparkz.core.consensus.History.{ModifierIds, Older}
 import sparkz.core.consensus.{History, HistoryReader, ModifierSemanticValidity, SyncInfo}
 import sparkz.core.network.message.SyncInfoMessageSpec
 import sparkz.core.serialization.SparkzSerializer
@@ -46,9 +46,9 @@ trait TestImplementations {
     override def modifierById(modifierId: sparkz.util.ModifierId): Option[TestModifier] = ???
     override def isSemanticallyValid(modifierId: sparkz.util.ModifierId): ModifierSemanticValidity = ???
     override def openSurfaceIds(): Seq[sparkz.util.ModifierId] = ???
-    override def continuationIds(info: TestSyncInfo, size: Int): ModifierIds = ???
-    override def syncInfo: TestSyncInfo = ???
-    override def compare(other: TestSyncInfo): History.HistoryComparisonResult = ???
+    override def continuationIds(info: TestSyncInfo, size: Int): ModifierIds = Seq()
+    override def syncInfo: TestSyncInfo = new TestSyncInfo
+    override def compare(other: TestSyncInfo): History.HistoryComparisonResult = Older
     override type NVCT = this.type
   }
 


### PR DESCRIPTION
…d respond with a sync message to let the peer to update its status as well.

The issue is described in this [jira ticket](https://horizenlabs.atlassian.net/browse/SDK-863).