### PR TITLE
Preserve the order of block during synchronization

### DIFF
--- a/src/main/scala/sparkz/ObjectGenerators.scala
+++ b/src/main/scala/sparkz/ObjectGenerators.scala
@@ -76,7 +76,7 @@ trait ObjectGenerators {
 
   lazy val modifiersGen: Gen[ModifiersData] = for {
     modifierTypeId: ModifierTypeId <- modifierTypeIdGen
-    modifiers: Map[ModifierId, Array[Byte]] <- Gen.nonEmptyMap(modifierWithIdGen).suchThat(_.nonEmpty)
+    modifiers: Seq[(ModifierId, Array[Byte])] <- Gen.nonEmptyListOf(modifierWithIdGen).suchThat(_.nonEmpty)
   } yield ModifiersData(modifierTypeId, modifiers)
 
   lazy val appVersionGen: Gen[Version] = for {

--- a/src/main/scala/sparkz/core/ModifiersCache.scala
+++ b/src/main/scala/sparkz/core/ModifiersCache.scala
@@ -22,7 +22,7 @@ trait ModifiersCache[PMOD <: PersistentNodeViewModifier, H <: HistoryReader[PMOD
   type K = sparkz.util.ModifierId
   type V = PMOD
 
-  protected val cache: mutable.Map[K, V] = mutable.Map[K, V]()
+  protected val cache: mutable.Map[K, V] = mutable.LinkedHashMap[K, V]()
 
   override def modifierById(modifierId: sparkz.util.ModifierId): Option[PMOD] = cache.get(modifierId)
 

--- a/src/test/scala/sparkz/core/network/MessageSpecification.scala
+++ b/src/test/scala/sparkz/core/network/MessageSpecification.scala
@@ -76,14 +76,14 @@ class MessageSpecification extends AnyPropSpec
         val recovered = modifiersSpec.parseByteString(bytes)
 
         recovered.typeId shouldEqual data.typeId
-        recovered.modifiers.keys.size shouldEqual data.modifiers.keys.size
+        recovered.modifiers.map(_._1).size shouldEqual data.modifiers.map(_._1).size
 
-        recovered.modifiers.keys.foreach { id =>
-          data.modifiers.get(id).isDefined shouldEqual true
+        recovered.modifiers.map(_._1).foreach { id =>
+          data.modifiers.exists(_._1 == id) shouldEqual true
         }
 
-        recovered.modifiers.values.toSet.foreach { v: Array[Byte] =>
-          data.modifiers.values.toSet.exists(_.sameElements(v)) shouldEqual true
+        recovered.modifiers.map(_._2).toSet.foreach { v: Array[Byte] =>
+          data.modifiers.map(_._2).toSet.exists(_.sameElements(v)) shouldEqual true
         }
 
         modifiersSpec.toByteString(data) shouldEqual bytes
@@ -93,8 +93,8 @@ class MessageSpecification extends AnyPropSpec
         val recovered2 = modifiersSpecLimited.parseByteString(bytes2)
 
         recovered2.typeId shouldEqual data.typeId
-        (recovered2.modifiers.keys.size == data.modifiers.keys.size) shouldEqual false
-        recovered2.modifiers.keys.size shouldEqual 0
+        (recovered2.modifiers.map(_._1).size == data.modifiers.map(_._1).size) shouldEqual false
+        recovered2.modifiers.map(_._1).size shouldEqual 0
       }
     }
   }

--- a/src/test/scala/sparkz/core/network/NodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/sparkz/core/network/NodeViewSynchronizerSpecification.scala
@@ -39,7 +39,7 @@ class NodeViewSynchronizerSpecification extends NetworkTests with TestImplementa
     val transaction = TestTransaction(1, 1)
     val txBytes = TestTransactionSerializer.toBytes(transaction)
 
-    synchronizer ! roundTrip(Message(modifiersSpec, Right(ModifiersData(Transaction.ModifierTypeId, Map(transaction.id -> txBytes))), Some(peer)))
+    synchronizer ! roundTrip(Message(modifiersSpec, Right(ModifiersData(Transaction.ModifierTypeId, Seq(transaction.id -> txBytes))), Some(peer)))
     viewHolder.expectMsg(TransactionsFromRemote(Seq(transaction)))
     networkController.expectNoMessage()
   }
@@ -48,7 +48,7 @@ class NodeViewSynchronizerSpecification extends NetworkTests with TestImplementa
     val transaction = TestTransaction(1, 1)
     val txBytes = TestTransactionSerializer.toBytes(transaction) ++ Array[Byte](0x01, 0x02)
 
-    synchronizer ! roundTrip(Message(modifiersSpec, Right(ModifiersData(Transaction.ModifierTypeId, Map(transaction.id -> txBytes))), Some(peer)))
+    synchronizer ! roundTrip(Message(modifiersSpec, Right(ModifiersData(Transaction.ModifierTypeId, Seq(transaction.id -> txBytes))), Some(peer)))
     viewHolder.expectMsg(TransactionsFromRemote(Seq(transaction)))
     networkController.expectMsg(PenalizePeer(peer.connectionId.remoteAddress, MisbehaviorPenalty))
   }


### PR DESCRIPTION
ModifiersData - Seq[(ModifierId, Array[Byte])] instead of Map[ModifierId, Array[Byte]] to keep the ordering, and because there is no real value of having a map. Also fix serialization-parsing to keep the order. And all related code to work with Seq now.
