### PR TITLE
Core Forgers Network Impl

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -99,6 +99,9 @@ sparkz {
     # Number of outgoing network connections
     maxOutgoingConnections = 10
 
+    # Number of outgoing network connections
+    maxForgerConnections = 20
+
     # Network connection timeout
     connectionTimeout = 1s
 
@@ -219,6 +222,9 @@ sparkz {
 
     # Enables transactions in the mempool
     handlingTransactionsEnabled = true
+
+    # Is this node a forger
+    isForgerNode = false
   }
 
   ntp {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -99,7 +99,7 @@ sparkz {
     # Number of outgoing network connections
     maxOutgoingConnections = 10
 
-    # Number of outgoing network connections
+    # Number of connections to forgers
     maxForgerConnections = 20
 
     # Network connection timeout

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -99,7 +99,7 @@ sparkz {
     # Number of outgoing network connections
     maxOutgoingConnections = 10
 
-    # Number of connections to forgers
+    # Number of dedicated connections to forgers. This works in addition to the maxOutgoingConnections ones
     maxForgerConnections = 20
 
     # Network connection timeout

--- a/src/main/scala/sparkz/core/network/NetworkController.scala
+++ b/src/main/scala/sparkz/core/network/NetworkController.scala
@@ -61,7 +61,7 @@ class NetworkController(settings: NetworkSettings,
 
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]
   private var unconfirmedConnections = Set.empty[InetSocketAddress]
-  private val maxConnections = settings.maxIncomingConnections + settings.maxOutgoingConnections
+  private val maxConnections = settings.maxIncomingConnections + settings.maxOutgoingConnections + settings.maxForgerConnections
   private val peersLastConnectionAttempts = new LRUSimpleCache[InetSocketAddress, TimeProvider.Time](threshold = 10000)
 
   private val tryNewConnectionAttemptDelay = 5.seconds
@@ -206,7 +206,7 @@ class NetworkController(settings: NetworkSettings,
     log.info(s"Unconfirmed connection: ($remoteAddress, $localAddress) => $connectionId")
 
     val handlerRef = sender()
-    if (connectionDirection.isOutgoing && canEstablishNewOutgoingConnection) {
+    if (connectionDirection.isOutgoing && (canEstablishNewOutgoingConnection || canEstablishNewForgerConnection)) {
       createPeerConnectionHandler(connectionId, handlerRef)
     }
     else if (connectionDirection.isIncoming && canEstablishNewIncomingConnection)
@@ -259,7 +259,7 @@ class NetworkController(settings: NetworkSettings,
   private def scheduleConnectionToPeer(): Unit = {
     context.system.scheduler.scheduleWithFixedDelay(5.seconds, tryNewConnectionAttemptDelay) {
       () => {
-        if (canEstablishNewOutgoingConnection) {
+        if (canEstablishNewOutgoingConnection || canEstablishNewForgerConnection) {
           log.trace(s"Looking for a new random connection")
           connectionToPeer(connections, unconfirmedConnections)
         }
@@ -275,12 +275,32 @@ class NetworkController(settings: NetworkSettings,
     getIncomingConnectionsSize < settings.maxIncomingConnections
   }
 
+  private def canEstablishNewForgerConnection: Boolean = {
+    getForgerConnectionsSize < settings.maxForgerConnections
+  }
+
+  private def shouldDropForgerConnection: Boolean = {
+    getForgerConnectionsSize > settings.maxForgerConnections
+  }
+
+  private def shouldDropOutgoingConnection: Boolean = {
+    getOutgoingConnectionsSize > settings.maxOutgoingConnections
+  }
+
+  private def shouldDropIncomingConnection: Boolean = {
+    getIncomingConnectionsSize > settings.maxIncomingConnections
+  }
+
   private def getOutgoingConnectionsSize: Int = {
     connections.count { p => p._2.connectionId.direction == Outgoing }
   }
 
   private def getIncomingConnectionsSize: Int = {
     connections.count { p => p._2.connectionId.direction == Incoming }
+  }
+
+  private def getForgerConnectionsSize: Int = {
+    connections.count { p => p._2.peerInfo.exists(_.peerSpec.forgerPeer) }
   }
 
   private def connectionToPeer(activeConnections: Map[InetSocketAddress, ConnectedPeer], unconfirmedConnections: Set[InetSocketAddress]): Unit = {
@@ -415,12 +435,21 @@ class NetworkController(settings: NetworkSettings,
       // Drop connection to self if occurred or peer already connected.
       // Decision whether connection is local or is from some other network is made
       // based on SessionIdPeerFeature if exists or in old way using isSelf() function
-      val shouldDrop =
+      var shouldDrop =
         connectionForPeerAddress(peerAddress).exists(_.handlerRef != peerHandlerRef) ||
         peerInfo.peerSpec.features.collectFirst {
           case SessionIdPeerFeature(networkMagic, sessionId) =>
             !networkMagic.sameElements(mySessionIdFeature.networkMagic) || sessionId == mySessionIdFeature.sessionId
         }.getOrElse(isSelf(remoteAddress))
+
+      // We allow temporary overflowing outgoing connection limits to get the peerInfo and see if peer if a forger.
+      // Drop connection if the peer does not fit in the limits.
+      val isForgerConnection = peerInfo.peerSpec.forgerPeer
+
+      shouldDrop = shouldDrop ||
+        (isForgerConnection && shouldDropForgerConnection) ||
+        (!isForgerConnection && peerInfo.connectionType.contains(Incoming) && shouldDropIncomingConnection) ||
+        (!isForgerConnection && peerInfo.connectionType.contains(Outgoing) && shouldDropOutgoingConnection)
 
       if (shouldDrop) {
         connectedPeer.handlerRef ! CloseConnection

--- a/src/main/scala/sparkz/core/network/NetworkController.scala
+++ b/src/main/scala/sparkz/core/network/NetworkController.scala
@@ -446,10 +446,8 @@ class NetworkController(settings: NetworkSettings,
       // Drop connection if the peer does not fit in the limits.
       val isForgerConnection = peerInfo.peerSpec.forgerPeer
 
-      shouldDrop = shouldDrop ||
-        (isForgerConnection && shouldDropForgerConnection) ||
-        (!isForgerConnection && peerInfo.connectionType.contains(Incoming) && shouldDropIncomingConnection) ||
-        (!isForgerConnection && peerInfo.connectionType.contains(Outgoing) && shouldDropOutgoingConnection)
+      val connectionLimitExhausted = isConnectionLimitExhausted(peerInfo, isForgerConnection)
+      shouldDrop = shouldDrop || connectionLimitExhausted
 
       if (shouldDrop) {
         connectedPeer.handlerRef ! CloseConnection
@@ -463,6 +461,12 @@ class NetworkController(settings: NetworkSettings,
         context.system.eventStream.publish(HandshakedPeer(updatedConnectedPeer))
       }
     }
+  }
+
+  private[network] def isConnectionLimitExhausted(peerInfo: PeerInfo, isForgerConnection: Boolean) = {
+    (isForgerConnection && shouldDropForgerConnection) ||
+      (!isForgerConnection && peerInfo.connectionType.contains(Incoming) && shouldDropIncomingConnection) ||
+      (!isForgerConnection && peerInfo.connectionType.contains(Outgoing) && shouldDropOutgoingConnection)
   }
 
   /**

--- a/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
@@ -102,7 +102,7 @@ class NodeViewSynchronizer[TX <: Transaction, SI <: SyncInfo, SIS <: SyncInfoMes
         if (m.modifierTypeId == Transaction.ModifierTypeId)
           networkControllerRef ! SendToNetwork(msg, BroadcastTransaction)
         else
-          networkControllerRef ! SendToNetwork(msg, BroadcastBlock(networkSettings))
+          networkControllerRef ! SendToNetwork(msg, Broadcast)
     }
   }
 

--- a/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
@@ -99,10 +99,10 @@ class NodeViewSynchronizer[TX <: Transaction, SI <: SyncInfo, SIS <: SyncInfoMes
         deliveryTracker.putInRebroadcastQueue(m.id)
       case _ =>
         val msg = Message(invSpec, Right(InvData(m.modifierTypeId, Seq(m.id))), None)
-	    if (m.modifierTypeId == Transaction.ModifierTypeId)
-	      networkControllerRef ! SendToNetwork(msg, BroadcastTransaction)
-	    else
-	      networkControllerRef ! SendToNetwork(msg, Broadcast)
+        if (m.modifierTypeId == Transaction.ModifierTypeId)
+          networkControllerRef ! SendToNetwork(msg, BroadcastTransaction)
+        else
+          networkControllerRef ! SendToNetwork(msg, BroadcastBlock(networkSettings))
     }
   }
 
@@ -198,8 +198,8 @@ class NodeViewSynchronizer[TX <: Transaction, SI <: SyncInfo, SIS <: SyncInfoMes
 
   // Send history extension to the (less developed) peer 'remote' which does not have it.
   @nowarn def sendExtension(remote: ConnectedPeer,
-                    status: HistoryComparisonResult,
-                    ext: Seq[(ModifierTypeId, ModifierId)]): Unit =
+                            status: HistoryComparisonResult,
+                            ext: Seq[(ModifierTypeId, ModifierId)]): Unit =
     ext.groupBy(_._1).mapValues(_.map(_._2)).foreach {
       case (mid, mods) =>
         networkControllerRef ! SendToNetwork(Message(invSpec, Right(InvData(mid, mods)), None), SendToPeer(remote))

--- a/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/sparkz/core/network/NodeViewSynchronizer.scala
@@ -102,7 +102,7 @@ class NodeViewSynchronizer[TX <: Transaction, SI <: SyncInfo, SIS <: SyncInfoMes
         if (m.modifierTypeId == Transaction.ModifierTypeId)
           networkControllerRef ! SendToNetwork(msg, BroadcastTransaction)
         else
-          networkControllerRef ! SendToNetwork(msg, Broadcast)
+          networkControllerRef ! SendToNetwork(msg, BroadcastBlock)
     }
   }
 

--- a/src/main/scala/sparkz/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/sparkz/core/network/PeerConnectionHandler.scala
@@ -247,7 +247,8 @@ class PeerConnectionHandler(val settings: NetworkSettings,
         Version(settings.appVersion),
         settings.nodeName,
         ownSocketAddress,
-        localFeatures
+        localFeatures,
+        settings.isForgerNode
       ),
       sparkzContext.timeProvider.time()
     )

--- a/src/main/scala/sparkz/core/network/PeerSpec.scala
+++ b/src/main/scala/sparkz/core/network/PeerSpec.scala
@@ -24,8 +24,7 @@ case class PeerSpec(agentName: String,
                     protocolVersion: Version,
                     nodeName: String,
                     declaredAddress: Option[InetSocketAddress],
-                    features: Seq[PeerFeature],
-                    forgerPeer: Boolean = false) {
+                    features: Seq[PeerFeature]) {
 
   lazy val localAddressOpt: Option[InetSocketAddress] = {
     features.collectFirst { case LocalAddressPeerFeature(addr) => addr }
@@ -73,7 +72,6 @@ class PeerSpecSerializer(featureSerializers: PeerFeature.Serializers) extends Sp
       w.putUShort(fBytes.length.toShortExact)
       w.putBytes(fBytes)
     }
-    w.putBoolean(obj.forgerPeer)
   }
 
   override def parse(r: Reader): PeerSpec = {
@@ -103,9 +101,7 @@ class PeerSpecSerializer(featureSerializers: PeerFeature.Serializers) extends Sp
       }
     }
 
-    val forgerPeer = r.getBoolean()
-
-    PeerSpec(appName, protocolVersion, nodeName, declaredAddressOpt, feats, forgerPeer)
+    PeerSpec(appName, protocolVersion, nodeName, declaredAddressOpt, feats)
   }
 
 }

--- a/src/main/scala/sparkz/core/network/PeerSpec.scala
+++ b/src/main/scala/sparkz/core/network/PeerSpec.scala
@@ -24,7 +24,8 @@ case class PeerSpec(agentName: String,
                     protocolVersion: Version,
                     nodeName: String,
                     declaredAddress: Option[InetSocketAddress],
-                    features: Seq[PeerFeature]) {
+                    features: Seq[PeerFeature],
+                    forgerPeer: Boolean = false) {
 
   lazy val localAddressOpt: Option[InetSocketAddress] = {
     features.collectFirst { case LocalAddressPeerFeature(addr) => addr }
@@ -72,6 +73,7 @@ class PeerSpecSerializer(featureSerializers: PeerFeature.Serializers) extends Sp
       w.putUShort(fBytes.length.toShortExact)
       w.putBytes(fBytes)
     }
+    w.putBoolean(obj.forgerPeer)
   }
 
   override def parse(r: Reader): PeerSpec = {
@@ -101,7 +103,9 @@ class PeerSpecSerializer(featureSerializers: PeerFeature.Serializers) extends Sp
       }
     }
 
-    PeerSpec(appName, protocolVersion, nodeName, declaredAddressOpt, feats)
+    val forgerPeer = r.getBoolean()
+
+    PeerSpec(appName, protocolVersion, nodeName, declaredAddressOpt, feats, forgerPeer)
   }
 
 }

--- a/src/main/scala/sparkz/core/network/SendingStrategy.scala
+++ b/src/main/scala/sparkz/core/network/SendingStrategy.scala
@@ -1,8 +1,10 @@
 package sparkz.core.network
 
-import sparkz.core.network.peer.TransactionsDisabledPeerFeature
+import sparkz.core.network.peer.{ForgerNodePeerFeature, TransactionsDisabledPeerFeature}
+import sparkz.core.settings.NetworkSettings
 
 import java.security.SecureRandom
+import scala.util.Random
 
 trait SendingStrategy {
   val secureRandom = new SecureRandom()
@@ -28,6 +30,14 @@ case object BroadcastTransaction extends SendingStrategy {
   override def choose(peers: Seq[ConnectedPeer]): Seq[ConnectedPeer] = {
     peers.filter(p => p.peerInfo.flatMap{
       info =>  info.peerSpec.features.collectFirst {case f:TransactionsDisabledPeerFeature => true}}.isEmpty)
+  }
+}
+
+case object BroadcastBlock extends SendingStrategy {
+  override def choose(peers: Seq[ConnectedPeer]): Seq[ConnectedPeer] = {
+    val (forgerPeers, remainingPeers) = peers.partition(_.peerInfo.exists(_.peerSpec.features.contains(ForgerNodePeerFeature())))
+
+    forgerPeers ++ remainingPeers
   }
 }
 

--- a/src/main/scala/sparkz/core/network/SendingStrategy.scala
+++ b/src/main/scala/sparkz/core/network/SendingStrategy.scala
@@ -38,8 +38,7 @@ case class BroadcastBlock(settings: NetworkSettings) extends SendingStrategy {
     (settings.maxOutgoingConnections + settings.maxIncomingConnections) / 2
 
   override def choose(peers: Seq[ConnectedPeer]): Seq[ConnectedPeer] = {
-    val forgerPeers = peers.filter(_.peerInfo.exists(_.peerSpec.forgerPeer))
-    val remainingPeers = peers.filter(_.peerInfo.exists(!_.peerSpec.forgerPeer))
+    val (forgerPeers, remainingPeers) = peers.partition(_.peerInfo.exists(_.peerSpec.forgerPeer))
 
     forgerPeers ++ Random.shuffle(remainingPeers).take(maxBlockBroadcastPeers - forgerPeers.length)
   }

--- a/src/main/scala/sparkz/core/network/SendingStrategy.scala
+++ b/src/main/scala/sparkz/core/network/SendingStrategy.scala
@@ -1,6 +1,6 @@
 package sparkz.core.network
 
-import sparkz.core.network.peer.TransactionsDisabledPeerFeature
+import sparkz.core.network.peer.{ForgerNodePeerFeature, TransactionsDisabledPeerFeature}
 import sparkz.core.settings.NetworkSettings
 
 import java.security.SecureRandom
@@ -38,7 +38,7 @@ case class BroadcastBlock(settings: NetworkSettings) extends SendingStrategy {
     (settings.maxOutgoingConnections + settings.maxIncomingConnections) / 2
 
   override def choose(peers: Seq[ConnectedPeer]): Seq[ConnectedPeer] = {
-    val (forgerPeers, remainingPeers) = peers.partition(_.peerInfo.exists(_.peerSpec.forgerPeer))
+    val (forgerPeers, remainingPeers) = peers.partition(_.peerInfo.exists(_.peerSpec.features.contains(ForgerNodePeerFeature())))
 
     forgerPeers ++ Random.shuffle(remainingPeers).take(maxBlockBroadcastPeers - forgerPeers.length)
   }

--- a/src/main/scala/sparkz/core/network/peer/ForgerNodePeerFeature.scala
+++ b/src/main/scala/sparkz/core/network/peer/ForgerNodePeerFeature.scala
@@ -6,7 +6,7 @@ import sparkz.util.serialization._
 import sparkz.core.serialization.SparkzSerializer
 
 /**
-  * This peer feature allows to detect peers who don't support transactions
+  * This peer feature marks forger nodes
   */
 case class ForgerNodePeerFeature() extends PeerFeature {
 

--- a/src/main/scala/sparkz/core/network/peer/ForgerNodePeerFeature.scala
+++ b/src/main/scala/sparkz/core/network/peer/ForgerNodePeerFeature.scala
@@ -1,0 +1,34 @@
+package sparkz.core.network.peer
+
+import sparkz.core.network.PeerFeature
+import sparkz.core.network.PeerFeature.Id
+import sparkz.util.serialization._
+import sparkz.core.serialization.SparkzSerializer
+
+/**
+  * This peer feature allows to detect peers who don't support transactions
+  */
+case class ForgerNodePeerFeature() extends PeerFeature {
+
+  override type M = ForgerNodePeerFeature
+  override val featureId: Id = ForgerNodePeerFeature.featureId
+
+  override def serializer: ForgerNodePeerFeatureSerializer.type = ForgerNodePeerFeatureSerializer
+
+}
+
+object ForgerNodePeerFeature {
+
+  val featureId: Id = 5: Byte
+
+}
+
+object ForgerNodePeerFeatureSerializer extends SparkzSerializer[ForgerNodePeerFeature] {
+
+
+  override def parse(r: Reader): ForgerNodePeerFeature = {
+    ForgerNodePeerFeature()
+  }
+
+  override def serialize(obj: ForgerNodePeerFeature, w: Writer): Unit = {}
+}

--- a/src/main/scala/sparkz/core/network/peer/PeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/PeerDatabase.scala
@@ -45,7 +45,7 @@ object PeerDatabase {
     */
   object PeerConfidence extends Enumeration {
     type PeerConfidence = Value
-    val Unknown, Low, Medium, High: Value = Value
+    val Unknown, Low, Medium, High, Forger: Value = Value
   }
 
   case class PeerDatabaseValue(address: InetSocketAddress, peerInfo: PeerInfo, confidence: PeerConfidence) {

--- a/src/main/scala/sparkz/core/network/peer/PeerManager.scala
+++ b/src/main/scala/sparkz/core/network/peer/PeerManager.scala
@@ -43,7 +43,7 @@ class PeerManager(
           PeerDatabaseValue(
             extractAddressFromPeerInfo(peerInfo),
             peerInfo,
-            if (peerInfo.peerSpec.forgerPeer) PeerConfidence.Forger else PeerConfidence.Unknown
+            if (peerInfo.peerSpec.features.contains(ForgerNodePeerFeature())) PeerConfidence.Forger else PeerConfidence.Unknown
           )
         )
       }
@@ -75,7 +75,8 @@ class PeerManager(
             val address: InetSocketAddress = peerSpec.address.getOrElse(throw new IllegalArgumentException())
             val peerInfo: PeerInfo = PeerInfo(peerSpec, 0L, None)
             log.info(s"New discovered peer: $peerInfo")
-            val peerConfidence = if (peerInfo.peerSpec.forgerPeer) PeerConfidence.Forger else PeerConfidence.Unknown
+            val peerConfidence =
+              if (peerInfo.peerSpec.features.contains(ForgerNodePeerFeature())) PeerConfidence.Forger else PeerConfidence.Unknown
             PeerDatabaseValue(address, peerInfo, peerConfidence)
         }
       peerDatabase.addOrUpdateKnownPeers(filteredPeers)

--- a/src/main/scala/sparkz/core/settings/Settings.scala
+++ b/src/main/scala/sparkz/core/settings/Settings.scala
@@ -9,7 +9,6 @@ import sparkz.core.network.message.Message
 import sparkz.core.utils.NetworkTimeProviderSettings
 import sparkz.util.SparkzLogging
 
-import scala.collection.Seq
 import scala.concurrent.duration._
 
 case class RESTApiSettings(bindAddress: InetSocketAddress,

--- a/src/main/scala/sparkz/core/settings/Settings.scala
+++ b/src/main/scala/sparkz/core/settings/Settings.scala
@@ -2,7 +2,6 @@ package sparkz.core.settings
 
 import java.io.File
 import java.net.InetSocketAddress
-
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
@@ -10,6 +9,7 @@ import sparkz.core.network.message.Message
 import sparkz.core.utils.NetworkTimeProviderSettings
 import sparkz.util.SparkzLogging
 
+import scala.collection.Seq
 import scala.concurrent.duration._
 
 case class RESTApiSettings(bindAddress: InetSocketAddress,
@@ -24,6 +24,7 @@ case class NetworkSettings(nodeName: String,
                            bindAddress: InetSocketAddress,
                            maxIncomingConnections: Int,
                            maxOutgoingConnections: Int,
+                           maxForgerConnections: Int,
                            connectionTimeout: FiniteDuration,
                            declaredAddress: Option[InetSocketAddress],
                            handshakeTimeout: FiniteDuration,
@@ -62,7 +63,8 @@ case class NetworkSettings(nodeName: String,
                            temporalBanDuration: FiniteDuration,
                            penaltySafeInterval: FiniteDuration,
                            penaltyScoreThreshold: Int,
-                           handlingTransactionsEnabled: Boolean)
+                           handlingTransactionsEnabled: Boolean,
+                           isForgerNode: Boolean)
 
 case class SparkzSettings(dataDir: File,
                           logDir: File,

--- a/src/test/scala/sparkz/core/network/NetworkTests.scala
+++ b/src/test/scala/sparkz/core/network/NetworkTests.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sparkz.core.app.Version
 import sparkz.core.network.NetworkTests.MockTimeProvider
-import sparkz.core.network.peer.PeerInfo
+import sparkz.core.network.peer.{ForgerNodePeerFeature, PeerInfo}
 import sparkz.core.settings.SparkzSettings
 import sparkz.core.utils.TimeProvider
 import sparkz.core.utils.TimeProvider.Time
@@ -19,7 +19,8 @@ class NetworkTests extends AnyFlatSpec with Matchers {
   protected def currentTime(): TimeProvider.Time = mockTimeProvider.time()
 
   protected def getPeerInfo(address: InetSocketAddress, nameOpt: Option[String] = None, featureSeq: Seq[PeerFeature] = Seq(), forgerNode: Boolean = false): PeerInfo = {
-    val data = PeerSpec("full node", Version.last, nameOpt.getOrElse(address.toString), Some(address), featureSeq, forgerNode)
+    val features = if (forgerNode) featureSeq :+ ForgerNodePeerFeature() else featureSeq
+    val data = PeerSpec("full node", Version.last, nameOpt.getOrElse(address.toString), Some(address), features)
     PeerInfo(data, currentTime(), None)
   }
 

--- a/src/test/scala/sparkz/core/network/NetworkTests.scala
+++ b/src/test/scala/sparkz/core/network/NetworkTests.scala
@@ -18,8 +18,8 @@ class NetworkTests extends AnyFlatSpec with Matchers {
 
   protected def currentTime(): TimeProvider.Time = mockTimeProvider.time()
 
-  protected def getPeerInfo(address: InetSocketAddress, nameOpt: Option[String] = None, featureSeq: Seq[PeerFeature] = Seq()): PeerInfo = {
-    val data = PeerSpec("full node", Version.last, nameOpt.getOrElse(address.toString), Some(address), featureSeq)
+  protected def getPeerInfo(address: InetSocketAddress, nameOpt: Option[String] = None, featureSeq: Seq[PeerFeature] = Seq(), forgerNode: Boolean = false): PeerInfo = {
+    val data = PeerSpec("full node", Version.last, nameOpt.getOrElse(address.toString), Some(address), featureSeq, forgerNode)
     PeerInfo(data, currentTime(), None)
   }
 


### PR DESCRIPTION
1. Core Forgers Network:
- PeerConfidence.Forger
- Peer limits and logic for Forger Network
- Prioritized connection
- Prioritized broadcasting

2. Simple Flag:

- send a boolean flag in the handshake message to tell that the node is a forger