### PR TITLE
SDK-1731 - node not able to get new peers other than the known one

### DIFF
--- a/src/main/scala/sparkz/core/network/NetworkController.scala
+++ b/src/main/scala/sparkz/core/network/NetworkController.scala
@@ -317,7 +317,7 @@ class NetworkController(settings: NetworkSettings,
 
     val peersAlreadyTriedFewTimeBefore = getPeersWeAlreadyTriedToConnectFewTimeAgo
 
-    val randomPeerF = peerManagerRef ? RandomPeerForConnectionExcluding(peersAddresses ++ peersAlreadyTriedFewTimeBefore)
+    val randomPeerF = peerManagerRef ? RandomPeerForConnectionExcluding(peersAddresses ++ peersAlreadyTriedFewTimeBefore, settings.onlyConnectToKnownPeers)
     randomPeerF.mapTo[Option[PeerInfo]].foreach {
       case Some(peerInfo) =>
         peerInfo.peerSpec.address.foreach(address => {

--- a/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
@@ -104,10 +104,7 @@ final class InMemoryPeerDatabase(sparkzSettings: SparkzSettings, sparkzContext: 
   }
 
   override def allPeers: Map[InetSocketAddress, PeerDatabaseValue] =
-    if (settings.onlyConnectToKnownPeers)
-      knownPeers
-    else
-      knownPeers ++ bucketManager.getTriedPeers ++ bucketManager.getNewPeers
+    knownPeers ++ bucketManager.getTriedPeers ++ bucketManager.getNewPeers
 
   override def blacklistedPeers: Seq[InetAddress] = blacklist
     .collect { case (address, bannedTill) if checkBanned(address, bannedTill) =>
@@ -174,10 +171,7 @@ final class InMemoryPeerDatabase(sparkzSettings: SparkzSettings, sparkzContext: 
     }
 
   override def randomPeersSubset: Map[InetSocketAddress, PeerDatabaseValue] =
-    if (settings.onlyConnectToKnownPeers)
-      knownPeers
-    else
-      knownPeers ++ bucketManager.getRandomPeers
+    knownPeers ++ bucketManager.getRandomPeers
 
   override def updatePeer(peerDatabaseValue: PeerDatabaseValue): Unit = {
     if (peerIsNotBlacklistedAndNotKnownPeer(peerDatabaseValue)) {

--- a/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/InMemoryPeerDatabase.scala
@@ -50,7 +50,7 @@ final class InMemoryPeerDatabase(sparkzSettings: SparkzSettings, sparkzContext: 
   // fill database with known peers
   settings.knownPeers.foreach { address =>
     if (!NetworkUtils.isSelf(address, settings.bindAddress, sparkzContext.externalNodeAddress)) {
-      knownPeers += address -> PeerDatabaseValue(address, PeerInfo.fromAddress(address), PeerConfidence.High)
+      knownPeers += address -> PeerDatabaseValue(address, PeerInfo.fromAddress(address), PeerConfidence.KnownPeer)
     }
   }
 

--- a/src/main/scala/sparkz/core/network/peer/PeerDatabase.scala
+++ b/src/main/scala/sparkz/core/network/peer/PeerDatabase.scala
@@ -45,7 +45,7 @@ object PeerDatabase {
     */
   object PeerConfidence extends Enumeration {
     type PeerConfidence = Value
-    val Unknown, Low, Medium, High, Forger: Value = Value
+    val Unknown, Low, Medium, KnownPeer, Forger: Value = Value
   }
 
   case class PeerDatabaseValue(address: InetSocketAddress, peerInfo: PeerInfo, confidence: PeerConfidence) {

--- a/src/test/scala/sparkz/core/network/peer/InMemoryPeerDatabaseSpec.scala
+++ b/src/test/scala/sparkz/core/network/peer/InMemoryPeerDatabaseSpec.scala
@@ -277,7 +277,7 @@ class InMemoryPeerDatabaseSpec extends NetworkTests with ObjectGenerators with B
       db.addOrUpdateKnownPeer(peerDatabaseValueThree)
 
       val allPeers = db.allPeers
-      allPeers.foreach(p => p._2.confidence shouldBe PeerConfidence.High)
+      allPeers.foreach(p => p._2.confidence shouldBe PeerConfidence.KnownPeer)
       allPeers.contains(firstAddress) shouldBe true
       allPeers.contains(secondAddress) shouldBe true
       allPeers.contains(thirdAddress) shouldBe true

--- a/src/test/scala/sparkz/core/network/peer/InMemoryPeerDatabaseSpec.scala
+++ b/src/test/scala/sparkz/core/network/peer/InMemoryPeerDatabaseSpec.scala
@@ -284,46 +284,6 @@ class InMemoryPeerDatabaseSpec extends NetworkTests with ObjectGenerators with B
     }
   }
 
-  it should "only return knownPeers if the flag is set to true" in {
-    val firstAddress = new InetSocketAddress(10)
-    val secondAddress = new InetSocketAddress(11)
-    val thirdAddress = new InetSocketAddress(12)
-    val forthAddress = new InetSocketAddress(13)
-    val fifthAddress = new InetSocketAddress(14)
-    val sixthAddress = new InetSocketAddress(15)
-    val knownPeers = Seq(firstAddress, secondAddress, thirdAddress)
-
-    def withDbHavingKnownPeers(test: InMemoryPeerDatabase => Assertion): Assertion =
-      test(new InMemoryPeerDatabase(
-        settings.copy(network = settings.network.copy(penaltySafeInterval = 1.seconds, knownPeers = knownPeers, onlyConnectToKnownPeers = true)),
-        sparkzContext
-      ))
-
-    withDbHavingKnownPeers { db =>
-      val extraPeerOne = PeerDatabaseValue(forthAddress, getPeerInfo(forthAddress), PeerConfidence.Unknown)
-      val extraPeerTwo = PeerDatabaseValue(fifthAddress, getPeerInfo(fifthAddress), PeerConfidence.Unknown)
-      val extraPeerThree = PeerDatabaseValue(sixthAddress, getPeerInfo(sixthAddress), PeerConfidence.Unknown)
-
-      db.addOrUpdateKnownPeer(extraPeerOne)
-      db.addOrUpdateKnownPeer(extraPeerTwo)
-      db.addOrUpdateKnownPeer(extraPeerThree)
-
-      val allPeers = db.allPeers
-      allPeers.size shouldBe 3
-      allPeers.foreach(p => p._2.confidence shouldBe PeerConfidence.High)
-      allPeers.contains(firstAddress) shouldBe true
-      allPeers.contains(secondAddress) shouldBe true
-      allPeers.contains(thirdAddress) shouldBe true
-
-      val randomPeersSubset = db.randomPeersSubset
-      randomPeersSubset.size shouldBe 3
-      randomPeersSubset.foreach(p => p._2.confidence shouldBe PeerConfidence.High)
-      randomPeersSubset.contains(firstAddress) shouldBe true
-      randomPeersSubset.contains(secondAddress) shouldBe true
-      randomPeersSubset.contains(thirdAddress) shouldBe true
-    }
-  }
-
   it should "check blacklisted peers expiration and return only not expired" in {
     withDb { db =>
       db.blacklistedPeers shouldBe empty


### PR DESCRIPTION
There's 2 separate issues that result in the problem with simplified compose nodes

first one if when flag onlyConnectToKnownPeers set to true, node only shares knownPeers, but not any other peers(incoming connections)

second is a bug in code that filters out knownPeers when sharing peers

these two combined result in a empty response for a request to share peers

it's been like this for quite some time, but probably 2 conditions rarely met together, allowing nodes to share the remaining connections